### PR TITLE
geom_alt props

### DIFF
--- a/data/421/175/035/421175035.geojson
+++ b/data/421/175/035/421175035.geojson
@@ -346,6 +346,9 @@
     },
     "wof:country":"KZ",
     "wof:created":1459009053,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"36af8c2c5ff011a2375b6c9398978e38",
     "wof:hierarchy":[
         {
@@ -356,7 +359,7 @@
         }
     ],
     "wof:id":421175035,
-    "wof:lastmodified":1561828608,
+    "wof:lastmodified":1582318987,
     "wof:name":"Aqtau",
     "wof:parent_id":85672923,
     "wof:placetype":"locality",

--- a/data/421/191/125/421191125.geojson
+++ b/data/421/191/125/421191125.geojson
@@ -994,6 +994,9 @@
     ],
     "wof:country":"KZ",
     "wof:created":1459009680,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b58562dd5438e643fb47b39c30797d93",
     "wof:hierarchy":[
         {
@@ -1004,7 +1007,7 @@
         }
     ],
     "wof:id":421191125,
-    "wof:lastmodified":1566591993,
+    "wof:lastmodified":1582318987,
     "wof:name":"Astana",
     "wof:parent_id":85672941,
     "wof:placetype":"locality",

--- a/data/421/196/855/421196855.geojson
+++ b/data/421/196/855/421196855.geojson
@@ -214,6 +214,9 @@
     },
     "wof:country":"KZ",
     "wof:created":1459009895,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"73578a3df217e7d409742f4f32960cbc",
     "wof:hierarchy":[
         {
@@ -224,7 +227,7 @@
         }
     ],
     "wof:id":421196855,
-    "wof:lastmodified":1566591992,
+    "wof:lastmodified":1582318987,
     "wof:name":"Beyneu",
     "wof:parent_id":85672923,
     "wof:placetype":"locality",

--- a/data/856/323/07/85632307.geojson
+++ b/data/856/323/07/85632307.geojson
@@ -1127,8 +1127,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso",
-        "naturalearth"
+        "meso"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1202,7 +1201,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1582318959,
+    "wof:lastmodified":1583205841,
     "wof:name":"Kazakhstan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/323/07/85632307.geojson
+++ b/data/856/323/07/85632307.geojson
@@ -1127,7 +1127,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso"
+        "meso",
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1180,6 +1181,11 @@
     },
     "wof:country":"KZ",
     "wof:country_alpha3":"KAZ",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "meso",
+        "naturalearth"
+    ],
     "wof:geomhash":"9b9b4c1a779331268e4b58f811aeb2f8",
     "wof:hierarchy":[
         {
@@ -1196,7 +1202,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591309,
+    "wof:lastmodified":1582318959,
     "wof:name":"Kazakhstan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/728/77/85672877.geojson
+++ b/data/856/728/77/85672877.geojson
@@ -368,6 +368,9 @@
         "wk:page":"Aktobe Region"
     },
     "wof:country":"KZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a421ed920ed38471c9669cb8dbe18390",
     "wof:hierarchy":[
         {
@@ -385,7 +388,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591321,
+    "wof:lastmodified":1582318967,
     "wof:name":"Aqt\u00f6be",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/728/79/85672879.geojson
+++ b/data/856/728/79/85672879.geojson
@@ -367,6 +367,9 @@
         "wk:page":"Kostanay Region"
     },
     "wof:country":"KZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5b02985ea9346d5a8c6ae8e9afeed800",
     "wof:hierarchy":[
         {
@@ -384,7 +387,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591319,
+    "wof:lastmodified":1582318966,
     "wof:name":"Qostanay",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/728/85/85672885.geojson
+++ b/data/856/728/85/85672885.geojson
@@ -363,6 +363,9 @@
         "wk:page":"Kyzylorda Region"
     },
     "wof:country":"KZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"299d3b5977516fa9fccc537a76a4b885",
     "wof:hierarchy":[
         {
@@ -380,7 +383,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591322,
+    "wof:lastmodified":1582318967,
     "wof:name":"Qyzylorda",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/728/89/85672889.geojson
+++ b/data/856/728/89/85672889.geojson
@@ -369,6 +369,9 @@
         "wk:page":"Atyrau Region"
     },
     "wof:country":"KZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"830a058db55ce8d7d085a34ec3885136",
     "wof:hierarchy":[
         {
@@ -386,7 +389,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591318,
+    "wof:lastmodified":1582318965,
     "wof:name":"Atyrau",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/728/93/85672893.geojson
+++ b/data/856/728/93/85672893.geojson
@@ -380,6 +380,9 @@
         "wk:page":"West Kazakhstan Region"
     },
     "wof:country":"KZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"35f1fc3773ca66c978b1a76b5ad3be3d",
     "wof:hierarchy":[
         {
@@ -397,7 +400,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591317,
+    "wof:lastmodified":1582318964,
     "wof:name":"West Kazakhstan",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/728/97/85672897.geojson
+++ b/data/856/728/97/85672897.geojson
@@ -372,6 +372,9 @@
         "wk:page":"Akmola Region"
     },
     "wof:country":"KZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a8841434544ad23a2d7b3826d8c06166",
     "wof:hierarchy":[
         {
@@ -389,7 +392,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591319,
+    "wof:lastmodified":1582318965,
     "wof:name":"Aqmola",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/05/85672905.geojson
+++ b/data/856/729/05/85672905.geojson
@@ -373,6 +373,9 @@
         "wk:page":"Karaganda Region"
     },
     "wof:country":"KZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2fb234704df3ef6863269832187cd282",
     "wof:hierarchy":[
         {
@@ -390,7 +393,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591323,
+    "wof:lastmodified":1582318968,
     "wof:name":"Qaraghandy",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/07/85672907.geojson
+++ b/data/856/729/07/85672907.geojson
@@ -379,6 +379,9 @@
         "wk:page":"North Kazakhstan Region"
     },
     "wof:country":"KZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9226604dc9a4aee00fb07c31881a6c81",
     "wof:hierarchy":[
         {
@@ -396,7 +399,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591327,
+    "wof:lastmodified":1582318970,
     "wof:name":"North Kazakhstan",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/11/85672911.geojson
+++ b/data/856/729/11/85672911.geojson
@@ -363,6 +363,9 @@
         "wk:page":"Pavlodar Region"
     },
     "wof:country":"KZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d197c72f4da5c8646fbd6b4c065a0cc9",
     "wof:hierarchy":[
         {
@@ -380,7 +383,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591325,
+    "wof:lastmodified":1582318969,
     "wof:name":"Pavlodar",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/15/85672915.geojson
+++ b/data/856/729/15/85672915.geojson
@@ -388,6 +388,9 @@
         "wk:page":"East Kazakhstan Region"
     },
     "wof:country":"KZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f41d9746e30e98e4510fdfd3c0fe99d",
     "wof:hierarchy":[
         {
@@ -405,7 +408,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591329,
+    "wof:lastmodified":1582318972,
     "wof:name":"East Kazakhstan",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/21/85672921.geojson
+++ b/data/856/729/21/85672921.geojson
@@ -372,6 +372,9 @@
         "wk:page":"Almaty Region"
     },
     "wof:country":"KZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"491811a021b98b7e7f234f35c02d819c",
     "wof:hierarchy":[
         {
@@ -389,7 +392,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591325,
+    "wof:lastmodified":1582318969,
     "wof:name":"Almaty",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/23/85672923.geojson
+++ b/data/856/729/23/85672923.geojson
@@ -360,6 +360,9 @@
         "wk:page":"Mangystau Region"
     },
     "wof:country":"KZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d0455eb1988850af5cb715f4006f92a",
     "wof:hierarchy":[
         {
@@ -377,7 +380,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591329,
+    "wof:lastmodified":1582318971,
     "wof:name":"Mangghystau",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/27/85672927.geojson
+++ b/data/856/729/27/85672927.geojson
@@ -416,6 +416,9 @@
         "wk:page":"South Kazakhstan Region"
     },
     "wof:country":"KZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b736a2c7a9c1e7904d88f299b6d64f30",
     "wof:hierarchy":[
         {
@@ -433,7 +436,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591324,
+    "wof:lastmodified":1582318968,
     "wof:name":"South Kazakhstan",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/31/85672931.geojson
+++ b/data/856/729/31/85672931.geojson
@@ -333,6 +333,9 @@
         "wk:page":"Jambyl Region"
     },
     "wof:country":"KZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"07bf03034817e73ee4bc0e56fd1246c8",
     "wof:hierarchy":[
         {
@@ -350,7 +353,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591328,
+    "wof:lastmodified":1582318971,
     "wof:name":"Zhambyl",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/37/85672937.geojson
+++ b/data/856/729/37/85672937.geojson
@@ -380,6 +380,9 @@
         1108785435
     ],
     "wof:country":"KZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2058eb3533afff91ba0f8a77662e4688",
     "wof:hierarchy":[
         {
@@ -397,7 +400,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591328,
+    "wof:lastmodified":1582318971,
     "wof:name":"Almaty City",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/41/85672941.geojson
+++ b/data/856/729/41/85672941.geojson
@@ -154,6 +154,9 @@
         421191125
     ],
     "wof:country":"KZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b58562dd5438e643fb47b39c30797d93",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1566591329,
+    "wof:lastmodified":1582318971,
     "wof:name":"Astana",
     "wof:parent_id":85632307,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.