### PR TITLE
Update properties of megacities

### DIFF
--- a/data/421/176/003/421176003.geojson
+++ b/data/421/176/003/421176003.geojson
@@ -621,6 +621,7 @@
     "wof:concordances":{
         "gn:id":1526384,
         "gp:id":2255777,
+        "ne:id":1159150969,
         "qs_pg:id":493451,
         "wd:id":"Q35493",
         "wk:page":"Almaty"
@@ -637,7 +638,8 @@
         }
     ],
     "wof:id":421176003,
-    "wof:lastmodified":1566591998,
+    "wof:lastmodified":1608688178,
+    "wof:megacity":1,
     "wof:name":"Almaty",
     "wof:parent_id":85672937,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary