### PR TITLE
kz concordances, placetype local, and more

### DIFF
--- a/data/110/878/529/9/1108785299.geojson
+++ b/data/110/878/529/9/1108785299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.497213,
-    "geom:area_square_m":20895950039.797478,
+    "geom:area_square_m":20895950119.091995,
     "geom:bbox":"47.050191,46.269943,49.936671,48.269475",
     "geom:latitude":47.41033,
     "geom:longitude":48.818822,
@@ -114,9 +114,10 @@
         "hasc:id":"KZ.AR.KU",
         "wd:id":"Q2737276"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837896,
-    "wof:geomhash":"ed4ac1de95ef85fbdc32c20ba9d06a10",
+    "wof:geomhash":"c470ccaf9550c3b3b2db50491ef57fd9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108785299,
-    "wof:lastmodified":1690938417,
+    "wof:lastmodified":1695886683,
     "wof:name":"Kurmangazinskiy",
     "wof:parent_id":85672889,
     "wof:placetype":"county",

--- a/data/110/878/530/1/1108785301.geojson
+++ b/data/110/878/530/1/1108785301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011497,
-    "geom:area_square_m":98235541.384716,
+    "geom:area_square_m":98235723.537046,
     "geom:bbox":"49.70425,46.201889,49.846584,46.366249",
     "geom:latitude":46.290365,
     "geom:longitude":49.785203,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AR.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837898,
-    "wof:geomhash":"b7bd283038ad51808087bf10c000744d",
+    "wof:geomhash":"7d7b4f9053fc80bacdef956928bc871f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785301,
-    "wof:lastmodified":1627522311,
+    "wof:lastmodified":1695886775,
     "wof:name":"Kurmangazinskiy",
     "wof:parent_id":85672889,
     "wof:placetype":"county",

--- a/data/110/878/530/5/1108785305.geojson
+++ b/data/110/878/530/5/1108785305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.822679,
-    "geom:area_square_m":6434787587.96844,
+    "geom:area_square_m":6434787320.091792,
     "geom:bbox":"80.289676,50.216232,81.759666,51.316303",
     "geom:latitude":50.760183,
     "geom:longitude":81.041882,
@@ -129,9 +129,10 @@
         "hasc:id":"KZ.EK.BO",
         "wd:id":"Q2550746"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837899,
-    "wof:geomhash":"fb793d8ff2304406201291eb22f7c91e",
+    "wof:geomhash":"fcf4aef0dad8f2796f05d8dcc8b42e61",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108785305,
-    "wof:lastmodified":1690938422,
+    "wof:lastmodified":1695886685,
     "wof:name":"Borodulikhinskiy",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/530/7/1108785307.geojson
+++ b/data/110/878/530/7/1108785307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.945175,
-    "geom:area_square_m":7443868473.09318,
+    "geom:area_square_m":7443869068.421832,
     "geom:bbox":"82.033254,49.857592,84.053774,51.014753",
     "geom:latitude":50.436761,
     "geom:longitude":83.044528,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.EK.GL",
         "wd:id":"Q893317"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837900,
-    "wof:geomhash":"c792470adaa8ea3c479507204410254b",
+    "wof:geomhash":"f3e93e066ccb9d580463ba591fc1912b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785307,
-    "wof:lastmodified":1690938421,
+    "wof:lastmodified":1695886685,
     "wof:name":"Glubokovskiy",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/530/9/1108785309.geojson
+++ b/data/110/878/530/9/1108785309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.561527,
-    "geom:area_square_m":14135220413.493591,
+    "geom:area_square_m":14135220882.367247,
     "geom:bbox":"77.089224,42.210844,80.807281,43.390613",
     "geom:latitude":42.939367,
     "geom:longitude":79.353222,
@@ -129,9 +129,10 @@
         "hasc:id":"KZ.AA.RA",
         "wd:id":"Q2556235"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837901,
-    "wof:geomhash":"493a9306578d83b9a953c89e7e16fab1",
+    "wof:geomhash":"044032104bccc2df846f8b3c6bf76586",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108785309,
-    "wof:lastmodified":1690938421,
+    "wof:lastmodified":1695886685,
     "wof:name":"Raiymbekskiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/531/1/1108785311.geojson
+++ b/data/110/878/531/1/1108785311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.206448,
-    "geom:area_square_m":10087333269.518188,
+    "geom:area_square_m":10087333470.75754,
     "geom:bbox":"84.203992,46.862866,85.702938,48.01991",
     "geom:latitude":47.453054,
     "geom:longitude":84.981877,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.EK.ZA",
         "wd:id":"Q2726370"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837902,
-    "wof:geomhash":"349726abf8cdade454d714cc38ae3c81",
+    "wof:geomhash":"b9e3a8b5e7e02399a619594deeca7380",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785311,
-    "wof:lastmodified":1690938429,
+    "wof:lastmodified":1695886689,
     "wof:name":"Zaysanskiy",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/531/3/1108785313.geojson
+++ b/data/110/878/531/3/1108785313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.598426,
-    "geom:area_square_m":12897983837.912701,
+    "geom:area_square_m":12897982969.782064,
     "geom:bbox":"84.101441,48.882417,87.3154,49.812674",
     "geom:latitude":49.263959,
     "geom:longitude":85.672292,
@@ -117,9 +117,10 @@
         "hasc:id":"KZ.EK.KK",
         "wd:id":"Q2550792"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837903,
-    "wof:geomhash":"8ff4dde42481a86aa60b60f5accd2b28",
+    "wof:geomhash":"f5c17c644cf4a44787cd02d8914d9e41",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108785313,
-    "wof:lastmodified":1690938429,
+    "wof:lastmodified":1695886690,
     "wof:name":"Katon-Karagayskiy",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/531/5/1108785315.geojson
+++ b/data/110/878/531/5/1108785315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
-    "geom:area_square_m":95.215489,
+    "geom:area_square_m":94.770306,
     "geom:bbox":"85.257946,49.588777,85.258526,49.5894",
     "geom:latitude":49.589129,
     "geom:longitude":85.258287,
@@ -88,9 +88,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.EK.ZY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837904,
-    "wof:geomhash":"4b048bf05e0897570ae9d13858ade6a7",
+    "wof:geomhash":"1566430328cd5da2aec63763432f1703",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108785315,
-    "wof:lastmodified":1636495697,
+    "wof:lastmodified":1695886661,
     "wof:name":"Zyryanovsk",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/878/531/7/1108785317.geojson
+++ b/data/110/878/531/7/1108785317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.982155,
-    "geom:area_square_m":8816851315.144672,
+    "geom:area_square_m":8816851656.526169,
     "geom:bbox":"74.13348,42.796248,75.823598,44.339349",
     "geom:latitude":43.447107,
     "geom:longitude":74.981306,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.ZM.KO",
         "wd:id":"Q2554520"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837906,
-    "wof:geomhash":"9fa38e8174ab32473e0d1bda5f2f127a",
+    "wof:geomhash":"02caca874aee46cc5737d591c4e64cf3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785317,
-    "wof:lastmodified":1690938428,
+    "wof:lastmodified":1695886690,
     "wof:name":"Kordayskiy",
     "wof:parent_id":85672931,
     "wof:placetype":"county",

--- a/data/110/878/531/9/1108785319.geojson
+++ b/data/110/878/531/9/1108785319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.743224,
-    "geom:area_square_m":6694281202.810739,
+    "geom:area_square_m":6694280703.909678,
     "geom:bbox":"72.331666,42.408899,73.959696,44.019077",
     "geom:latitude":43.244208,
     "geom:longitude":73.150872,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.ZM.ME",
         "wd:id":"Q2549670"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837907,
-    "wof:geomhash":"af83646f0f966289613178da68f12a5a",
+    "wof:geomhash":"64b6e536182ee4328e03624308285386",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785319,
-    "wof:lastmodified":1690938428,
+    "wof:lastmodified":1695886689,
     "wof:name":"Merkenskiy",
     "wof:parent_id":85672931,
     "wof:placetype":"county",

--- a/data/110/878/532/3/1108785323.geojson
+++ b/data/110/878/532/3/1108785323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.828588,
-    "geom:area_square_m":6487427311.845627,
+    "geom:area_square_m":6487428430.851213,
     "geom:bbox":"55.905081,50.209552,57.693455,51.115111",
     "geom:latitude":50.714003,
     "geom:longitude":56.738985,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.AT.MA",
         "wd:id":"Q2550413"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837908,
-    "wof:geomhash":"36d90436aa8169d225953d00aca2167c",
+    "wof:geomhash":"14ba33b6ca3646293aac55de9cb66d8c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785323,
-    "wof:lastmodified":1690938414,
+    "wof:lastmodified":1695886681,
     "wof:name":"Martukskiy",
     "wof:parent_id":85672877,
     "wof:placetype":"county",

--- a/data/110/878/532/5/1108785325.geojson
+++ b/data/110/878/532/5/1108785325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.724661,
-    "geom:area_square_m":5622533388.203456,
+    "geom:area_square_m":5622533359.040902,
     "geom:bbox":"52.413537,50.683033,53.633866,51.534622",
     "geom:latitude":51.135673,
     "geom:longitude":53.036726,
@@ -114,9 +114,10 @@
         "hasc:id":"KZ.WK.BU",
         "wd:id":"Q2737283"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837909,
-    "wof:geomhash":"50cb648863c3afe269c4aa8337b1cc6f",
+    "wof:geomhash":"1db2f9a16f0ad6464220561ffe8c48e5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108785325,
-    "wof:lastmodified":1690938414,
+    "wof:lastmodified":1695886682,
     "wof:name":"Burlinskiy",
     "wof:parent_id":85672893,
     "wof:placetype":"county",

--- a/data/110/878/532/7/1108785327.geojson
+++ b/data/110/878/532/7/1108785327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.034537,
-    "geom:area_square_m":8280781559.411769,
+    "geom:area_square_m":8280781792.479445,
     "geom:bbox":"46.779962,49.061646,48.101682,50.463886",
     "geom:latitude":49.658681,
     "geom:longitude":47.435047,
@@ -114,9 +114,10 @@
         "hasc:id":"KZ.WK.DB",
         "wd:id":"Q2736676"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837910,
-    "wof:geomhash":"ee63cd31162bdc9dd3b535c230db43b8",
+    "wof:geomhash":"c52bb612898b66520fc65df2f3ff13e2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108785327,
-    "wof:lastmodified":1690938413,
+    "wof:lastmodified":1695886681,
     "wof:name":"Dzhanybekskiy",
     "wof:parent_id":85672893,
     "wof:placetype":"county",

--- a/data/110/878/532/9/1108785329.geojson
+++ b/data/110/878/532/9/1108785329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.02129,
-    "geom:area_square_m":7982935659.874844,
+    "geom:area_square_m":7982935794.285914,
     "geom:bbox":"48.98297,50.248368,50.86638,51.285948",
     "geom:latitude":50.791498,
     "geom:longitude":49.928715,
@@ -114,9 +114,10 @@
         "hasc:id":"KZ.WK.TA",
         "wd:id":"Q387436"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837911,
-    "wof:geomhash":"18d438b248e1081f76b3f1e690612266",
+    "wof:geomhash":"48ac2023645afad59fe01a54f547eaaa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108785329,
-    "wof:lastmodified":1690938413,
+    "wof:lastmodified":1695886681,
     "wof:name":"Taskalinskiy",
     "wof:parent_id":85672893,
     "wof:placetype":"county",

--- a/data/110/878/533/1/1108785331.geojson
+++ b/data/110/878/533/1/1108785331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.057883,
-    "geom:area_square_m":8178729039.668431,
+    "geom:area_square_m":8178729129.841406,
     "geom:bbox":"50.256451,50.620244,52.557545,51.776105",
     "geom:latitude":51.299651,
     "geom:longitude":51.245227,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.WK.ZE",
         "wd:id":"Q2737304"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837912,
-    "wof:geomhash":"a1b2a1feb974a761047baf365e682158",
+    "wof:geomhash":"76485e5bb30250f7a8ab70b6987a0bc3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785331,
-    "wof:lastmodified":1690938403,
+    "wof:lastmodified":1695886677,
     "wof:name":"Zelenovskiy",
     "wof:parent_id":85672893,
     "wof:placetype":"county",

--- a/data/110/878/533/3/1108785333.geojson
+++ b/data/110/878/533/3/1108785333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.950582,
-    "geom:area_square_m":6975485967.373611,
+    "geom:area_square_m":6975486015.328873,
     "geom:bbox":"60.896175,53.055528,62.47587,54.086611",
     "geom:latitude":53.597405,
     "geom:longitude":61.781794,
@@ -114,9 +114,10 @@
         "hasc:id":"KZ.QS.KB",
         "wd:id":"Q1377553"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837918,
-    "wof:geomhash":"4cbb250e29ce48b4f449225f57986f95",
+    "wof:geomhash":"cd304b3176c017514472a9918bbd7963",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108785333,
-    "wof:lastmodified":1690938404,
+    "wof:lastmodified":1695886678,
     "wof:name":"Karabalykskiy",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/533/5/1108785335.geojson
+++ b/data/110/878/533/5/1108785335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.96518,
-    "geom:area_square_m":7065572578.929906,
+    "geom:area_square_m":7065573715.565207,
     "geom:bbox":"62.077804,52.918377,63.722055,54.231363",
     "geom:latitude":53.698771,
     "geom:longitude":62.866533,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.QS.FY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837920,
-    "wof:geomhash":"c552500ce47b0e80aa5e235315cec232",
+    "wof:geomhash":"77bbcf910ab8c6a5fd5bc4397d611498",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785335,
-    "wof:lastmodified":1627522310,
+    "wof:lastmodified":1695886773,
     "wof:name":"Fyodorovskiy",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/533/7/1108785337.geojson
+++ b/data/110/878/533/7/1108785337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.493069,
-    "geom:area_square_m":4411615305.480824,
+    "geom:area_square_m":4411615448.262626,
     "geom:bbox":"51.028593,43.158408,52.000934,44.144639",
     "geom:latitude":43.648254,
     "geom:longitude":51.567523,
@@ -105,9 +105,10 @@
         "hasc:id":"KZ.MG.KA",
         "wd:id":"Q720411"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837922,
-    "wof:geomhash":"a09dab29693fd4b8ab1969cb8874e333",
+    "wof:geomhash":"faedc9b90bf59543080c6bc3759775da",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108785337,
-    "wof:lastmodified":1690938403,
+    "wof:lastmodified":1695886677,
     "wof:name":"Karakiyanskiy",
     "wof:parent_id":85672923,
     "wof:placetype":"county",

--- a/data/110/878/534/1/1108785341.geojson
+++ b/data/110/878/534/1/1108785341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.961917,
-    "geom:area_square_m":8457453986.79302,
+    "geom:area_square_m":8457455489.121052,
     "geom:bbox":"50.219501,43.732516,52.110451,45.364834",
     "geom:latitude":44.678267,
     "geom:longitude":51.209345,
@@ -111,9 +111,10 @@
         "hasc:id":"KZ.MG.TU",
         "wd:id":"Q720422"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837923,
-    "wof:geomhash":"fbe3023695000939fa1ed7d955cb1f19",
+    "wof:geomhash":"dc4fa867a70728898589bc95fbfb0400",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108785341,
-    "wof:lastmodified":1690938405,
+    "wof:lastmodified":1695886678,
     "wof:name":"Tupkaraganskiy",
     "wof:parent_id":85672923,
     "wof:placetype":"county",

--- a/data/110/878/534/3/1108785343.geojson
+++ b/data/110/878/534/3/1108785343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005248,
-    "geom:area_square_m":45959819.108675,
+    "geom:area_square_m":45959691.391533,
     "geom:bbox":"50.618389,44.854973,50.781612,44.978222",
     "geom:latitude":44.91304,
     "geom:longitude":50.69888,
@@ -111,9 +111,10 @@
         "hasc:id":"KZ.MG.TU",
         "wd:id":"Q720422"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837924,
-    "wof:geomhash":"5ab29fd5901a10ee8476627ece3474a8",
+    "wof:geomhash":"13ce5de0a98f43f12b2d891dda63be2b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108785343,
-    "wof:lastmodified":1690938405,
+    "wof:lastmodified":1695886678,
     "wof:name":"Tupkaraganskiy",
     "wof:parent_id":85672923,
     "wof:placetype":"county",

--- a/data/110/878/534/5/1108785345.geojson
+++ b/data/110/878/534/5/1108785345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008976,
-    "geom:area_square_m":78584594.874425,
+    "geom:area_square_m":78584584.940336,
     "geom:bbox":"49.993946,44.817554,50.211113,45.055195",
     "geom:latitude":44.925622,
     "geom:longitude":50.066939,
@@ -111,9 +111,10 @@
         "hasc:id":"KZ.MG.TU",
         "wd:id":"Q720422"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837926,
-    "wof:geomhash":"7a78f5af1e23675ef6966026a3edbe31",
+    "wof:geomhash":"d01f0543a387cf5786dc2ee4b1274062",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108785345,
-    "wof:lastmodified":1690938405,
+    "wof:lastmodified":1695886678,
     "wof:name":"Tupkaraganskiy",
     "wof:parent_id":85672923,
     "wof:placetype":"county",

--- a/data/110/878/534/7/1108785347.geojson
+++ b/data/110/878/534/7/1108785347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017063,
-    "geom:area_square_m":149214752.50652,
+    "geom:area_square_m":149214880.130541,
     "geom:bbox":"50.215221,44.868416,50.365223,45.069916",
     "geom:latitude":44.990039,
     "geom:longitude":50.292933,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.MG.TU",
         "wd:id":"Q720422"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837927,
-    "wof:geomhash":"5cd5e36216f9490754352dcfca89611f",
+    "wof:geomhash":"7fd65cf57925170af8cb5254b9741def",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785347,
-    "wof:lastmodified":1690938404,
+    "wof:lastmodified":1695886678,
     "wof:name":"Tupkaraganskiy",
     "wof:parent_id":85672923,
     "wof:placetype":"county",

--- a/data/110/878/534/9/1108785349.geojson
+++ b/data/110/878/534/9/1108785349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.037046,
-    "geom:area_square_m":7560509650.973644,
+    "geom:area_square_m":7560509765.185563,
     "geom:bbox":"75.010488,53.335478,77.068333,54.457595",
     "geom:latitude":53.871553,
     "geom:longitude":76.017835,
@@ -117,9 +117,10 @@
         "hasc:id":"KZ.PA.ZH",
         "wd:id":"Q44486"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837928,
-    "wof:geomhash":"cac085ae9ceecdec2384e79186714e8a",
+    "wof:geomhash":"e064c9124174c218175a75d1af4755f0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108785349,
-    "wof:lastmodified":1690938404,
+    "wof:lastmodified":1695886678,
     "wof:name":"Zhelezinskiy",
     "wof:parent_id":85672911,
     "wof:placetype":"county",

--- a/data/110/878/535/1/1108785351.geojson
+++ b/data/110/878/535/1/1108785351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.726382,
-    "geom:area_square_m":5398111633.823797,
+    "geom:area_square_m":5398111840.262628,
     "geom:bbox":"76.830436,52.676637,78.323623,53.57839",
     "geom:latitude":53.058071,
     "geom:longitude":77.521514,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.PA.US",
         "wd:id":"Q2554534"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837929,
-    "wof:geomhash":"17c837da66365746f04a81bd4ad27429",
+    "wof:geomhash":"3f4c82b3a8b1d3582c2ed5d1a61e7675",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785351,
-    "wof:lastmodified":1690938412,
+    "wof:lastmodified":1695886681,
     "wof:name":"Uspenskiy",
     "wof:parent_id":85672911,
     "wof:placetype":"county",

--- a/data/110/878/535/3/1108785353.geojson
+++ b/data/110/878/535/3/1108785353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.083782,
-    "geom:area_square_m":7743492723.088264,
+    "geom:area_square_m":7743492970.756565,
     "geom:bbox":"69.819908,53.969557,71.293468,55.310033",
     "geom:latitude":54.701916,
     "geom:longitude":70.583548,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.NK.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837930,
-    "wof:geomhash":"5e94b1a67699ade03b28216fb330acbb",
+    "wof:geomhash":"5826924489f4c7ec60465fc76e5ed097",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785353,
-    "wof:lastmodified":1627522309,
+    "wof:lastmodified":1695886772,
     "wof:name":"Bulaevskiy",
     "wof:parent_id":85672907,
     "wof:placetype":"county",

--- a/data/110/878/535/5/1108785355.geojson
+++ b/data/110/878/535/5/1108785355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.901776,
-    "geom:area_square_m":6404216960.184235,
+    "geom:area_square_m":6404216967.593715,
     "geom:bbox":"68.381792,54.332234,70.197099,55.441984",
     "geom:latitude":54.946377,
     "geom:longitude":69.200168,
@@ -111,9 +111,10 @@
         "hasc:id":"KZ.NK.KY",
         "wd:id":"Q25577"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837931,
-    "wof:geomhash":"64d7cb2f551a06c9daf48654035bcaf2",
+    "wof:geomhash":"3f5e72fb7737ce09291d756af2a06f18",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108785355,
-    "wof:lastmodified":1690938413,
+    "wof:lastmodified":1695886775,
     "wof:name":"Kyzylzharskiy",
     "wof:parent_id":85672907,
     "wof:placetype":"county",

--- a/data/110/878/535/9/1108785359.geojson
+++ b/data/110/878/535/9/1108785359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.595353,
-    "geom:area_square_m":4243921978.189027,
+    "geom:area_square_m":4243921578.175611,
     "geom:bbox":"67.489618,54.379949,68.942526,55.21881",
     "geom:latitude":54.79565,
     "geom:longitude":68.264327,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.NK.MA",
         "wd:id":"Q32419"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837932,
-    "wof:geomhash":"c4e6522f8d3f9ad33f821bad7d762a71",
+    "wof:geomhash":"5516f2017803e4d0593b463238bf2baa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785359,
-    "wof:lastmodified":1690938412,
+    "wof:lastmodified":1695886775,
     "wof:name":"Mamlyutskiy",
     "wof:parent_id":85672907,
     "wof:placetype":"county",

--- a/data/110/878/536/1/1108785361.geojson
+++ b/data/110/878/536/1/1108785361.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.187239,
-    "geom:area_square_m":1752335592.839905,
+    "geom:area_square_m":1752335492.966591,
     "geom:bbox":"67.936153,40.568584,68.663579,41.044272",
     "geom:latitude":40.810983,
     "geom:longitude":68.338916,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.SK.MA",
         "wd:id":"Q2554567"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837933,
-    "wof:geomhash":"340f629d609689801b7a7b35aacbe6f5",
+    "wof:geomhash":"3eba43f80bde53b72885cfd575ab7efb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785361,
-    "wof:lastmodified":1690938430,
+    "wof:lastmodified":1695886775,
     "wof:name":"Maktaaral`skiy",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/536/3/1108785363.geojson
+++ b/data/110/878/536/3/1108785363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.069113,
-    "geom:area_square_m":64031251383.173149,
+    "geom:area_square_m":64031252131.081253,
     "geom:bbox":"51.266285,41.246392,55.998951,44.351628",
     "geom:latitude":42.897246,
     "geom:longitude":54.280224,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.MG.KA",
         "wd:id":"Q2476548"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837934,
-    "wof:geomhash":"06fd0e5346b7a13194da2a55dc831a65",
+    "wof:geomhash":"074e40e114a93e2a9b5299b8532c535b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785363,
-    "wof:lastmodified":1690938430,
+    "wof:lastmodified":1695886690,
     "wof:name":"Karakiyanskiy",
     "wof:parent_id":85672923,
     "wof:placetype":"county",

--- a/data/110/878/536/5/1108785365.geojson
+++ b/data/110/878/536/5/1108785365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.404903,
-    "geom:area_square_m":12998533228.902271,
+    "geom:area_square_m":12998533254.267395,
     "geom:bbox":"66.532396,40.967495,68.643404,42.172257",
     "geom:latitude":41.560189,
     "geom:longitude":67.438851,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.SK.CH",
         "wd:id":"Q2605432"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837935,
-    "wof:geomhash":"902fdce3259d9453c44a20a2e6f4285a",
+    "wof:geomhash":"adc45efffea78ada1c18d366ee3467e7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785365,
-    "wof:lastmodified":1690938430,
+    "wof:lastmodified":1695886774,
     "wof:name":"Chardarinskiy",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/536/7/1108785367.geojson
+++ b/data/110/878/536/7/1108785367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.754418,
-    "geom:area_square_m":12956748568.75959,
+    "geom:area_square_m":12956749058.183817,
     "geom:bbox":"71.602738,52.592372,74.04072,54.137095",
     "geom:latitude":53.325322,
     "geom:longitude":72.8717,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.NK.UA",
         "wd:id":"Q30516"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837936,
-    "wof:geomhash":"8949be9dd05ed35e4558a478b54a2704",
+    "wof:geomhash":"348e22b728d4b17ff72478315c20dfde",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785367,
-    "wof:lastmodified":1690938430,
+    "wof:lastmodified":1695886690,
     "wof:name":"Ualikhanovskiy",
     "wof:parent_id":85672907,
     "wof:placetype":"county",

--- a/data/110/878/536/9/1108785369.geojson
+++ b/data/110/878/536/9/1108785369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.340083,
-    "geom:area_square_m":3115318340.547718,
+    "geom:area_square_m":3115318859.097754,
     "geom:bbox":"69.45056,41.917778,70.943222,42.410834",
     "geom:latitude":42.19794,
     "geom:longitude":70.237135,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.SK.TO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837937,
-    "wof:geomhash":"33980609702a7692dab57df51cd50981",
+    "wof:geomhash":"f1d1849754789e0dc7c91eb8e54f2a2a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785369,
-    "wof:lastmodified":1627522314,
+    "wof:lastmodified":1695886777,
     "wof:name":"Tolebiyskiy",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/537/1/1108785371.geojson
+++ b/data/110/878/537/1/1108785371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000902,
-    "geom:area_square_m":6693639.925437,
+    "geom:area_square_m":6693674.268223,
     "geom:bbox":"70.662619,53.104101,70.722546,53.124615",
     "geom:latitude":53.114114,
     "geom:longitude":70.690339,
@@ -59,9 +59,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AM.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837938,
-    "wof:geomhash":"61526e79d75d471a5790ea648a0f6675",
+    "wof:geomhash":"d16ca5c0d1b25198c82d19194e8d934e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108785371,
-    "wof:lastmodified":1627522310,
+    "wof:lastmodified":1695886774,
     "wof:name":"Shuchinskiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/537/3/1108785373.geojson
+++ b/data/110/878/537/3/1108785373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000509,
-    "geom:area_square_m":4576356.586715,
+    "geom:area_square_m":4576450.342634,
     "geom:bbox":"77.135898,43.336753,77.166882,43.359922",
     "geom:latitude":43.348969,
     "geom:longitude":77.151711,
@@ -59,9 +59,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AA.TG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837939,
-    "wof:geomhash":"01da46b90a9c397a27273a7a88d5f577",
+    "wof:geomhash":"5fd432e478a239247cdefd30d573d0d8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108785373,
-    "wof:lastmodified":1627522313,
+    "wof:lastmodified":1695886776,
     "wof:name":"Talgarskiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/537/7/1108785377.geojson
+++ b/data/110/878/537/7/1108785377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000054,
-    "geom:area_square_m":404065.817923,
+    "geom:area_square_m":404033.95234,
     "geom:bbox":"63.085,52.957993,63.100431,52.963983",
     "geom:latitude":52.960548,
     "geom:longitude":63.093252,
@@ -117,9 +117,10 @@
         "hasc:id":"KZ.QS.TA",
         "wd:id":"Q619361"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837940,
-    "wof:geomhash":"0a89c0114c170dd2e0a516b12f9ae5be",
+    "wof:geomhash":"aa45a2e366f9e744385b5523d1da56e4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108785377,
-    "wof:lastmodified":1690938421,
+    "wof:lastmodified":1695886685,
     "wof:name":"Taranovskiy",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/537/9/1108785379.geojson
+++ b/data/110/878/537/9/1108785379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000276,
-    "geom:area_square_m":1961923.289471,
+    "geom:area_square_m":1961954.38897,
     "geom:bbox":"68.81522,54.83912,68.833033,54.858594",
     "geom:latitude":54.848319,
     "geom:longitude":68.82415,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.NK.KY",
         "wd:id":"Q32419"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837941,
-    "wof:geomhash":"a93992716ba916608d43b3cb81a3afbf",
+    "wof:geomhash":"de9a8427360f61655d0bfb1bafce5a38",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785379,
-    "wof:lastmodified":1690938420,
+    "wof:lastmodified":1695886775,
     "wof:name":"Kyzylzharskiy",
     "wof:parent_id":85672907,
     "wof:placetype":"county",

--- a/data/110/878/538/1/1108785381.geojson
+++ b/data/110/878/538/1/1108785381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091009,
-    "geom:area_square_m":814252861.730791,
+    "geom:area_square_m":814252789.856578,
     "geom:bbox":"51.079182,43.356761,51.560669,43.829057",
     "geom:latitude":43.651192,
     "geom:longitude":51.309236,
@@ -59,9 +59,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.MG.AQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837942,
-    "wof:geomhash":"6ce4c7a81aab1a09d988d24222313e17",
+    "wof:geomhash":"0edccdceb4bd6ac1e558a9c39331acb5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108785381,
-    "wof:lastmodified":1627522308,
+    "wof:lastmodified":1695886772,
     "wof:name":"Aqtau",
     "wof:parent_id":85672923,
     "wof:placetype":"county",

--- a/data/110/878/538/3/1108785383.geojson
+++ b/data/110/878/538/3/1108785383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00005,
-    "geom:area_square_m":452046.824815,
+    "geom:area_square_m":452103.590932,
     "geom:bbox":"51.324237,43.356761,51.338325,43.364451",
     "geom:latitude":43.359982,
     "geom:longitude":51.330569,
@@ -59,9 +59,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.MG.AQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837943,
-    "wof:geomhash":"0b108a1412feeef979e0adb671bb15cc",
+    "wof:geomhash":"f14ddde71cc3f84e646e0babcedb26db",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108785383,
-    "wof:lastmodified":1627522308,
+    "wof:lastmodified":1695886772,
     "wof:name":"Aqtau",
     "wof:parent_id":85672923,
     "wof:placetype":"county",

--- a/data/110/878/538/5/1108785385.geojson
+++ b/data/110/878/538/5/1108785385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.89904,
-    "geom:area_square_m":6544238643.633736,
+    "geom:area_square_m":6544239108.186745,
     "geom:bbox":"63.538538,53.471245,64.993274,54.39804",
     "geom:latitude":53.93631,
     "geom:longitude":64.318484,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.QS.ME",
         "wd:id":"Q793969"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837944,
-    "wof:geomhash":"3294210d1aa78cac0da9472893d9a115",
+    "wof:geomhash":"0533fae7678a026108f918201d3d23d3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785385,
-    "wof:lastmodified":1690938428,
+    "wof:lastmodified":1695886689,
     "wof:name":"Mendykarinskiy",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/538/7/1108785387.geojson
+++ b/data/110/878/538/7/1108785387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.387934,
-    "geom:area_square_m":10690725729.109261,
+    "geom:area_square_m":10690725081.917324,
     "geom:bbox":"67.755799,50.616834,69.333297,52.213146",
     "geom:latitude":51.468604,
     "geom:longitude":68.458759,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.AM.AT",
         "wd:id":"Q4812946"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837945,
-    "wof:geomhash":"cfdb66e7922d410a0221345bd92be7ef",
+    "wof:geomhash":"5326f0df2bc1040291668b0fb110059a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785387,
-    "wof:lastmodified":1690938427,
+    "wof:lastmodified":1695886688,
     "wof:name":"Atbasarskiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/538/9/1108785389.geojson
+++ b/data/110/878/538/9/1108785389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.697976,
-    "geom:area_square_m":5283620619.611286,
+    "geom:area_square_m":5283620578.307015,
     "geom:bbox":"69.179224,51.767513,71.059048,52.700141",
     "geom:latitude":52.251351,
     "geom:longitude":70.052464,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.AM.BU",
         "wd:id":"Q4703463"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837946,
-    "wof:geomhash":"35df659c80d957274977ebfdb083c2f4",
+    "wof:geomhash":"29a7ce43e1a203d8dcbf8afd1ec974ff",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785389,
-    "wof:lastmodified":1690938427,
+    "wof:lastmodified":1695886688,
     "wof:name":"Bulandynskiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/539/1/1108785391.geojson
+++ b/data/110/878/539/1/1108785391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.955965,
-    "geom:area_square_m":7360181522.218036,
+    "geom:area_square_m":7360181971.991149,
     "geom:bbox":"68.945343,51.03465,70.491509,52.025197",
     "geom:latitude":51.489549,
     "geom:longitude":69.710884,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.AM.AS",
         "wd:id":"Q2466344"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837947,
-    "wof:geomhash":"259cfec0d30836298de9083b01cdd8df",
+    "wof:geomhash":"4191693e2198664ace5a48c63de3dbfe",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785391,
-    "wof:lastmodified":1690938422,
+    "wof:lastmodified":1695886686,
     "wof:name":"Astrakhansiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/539/5/1108785395.geojson
+++ b/data/110/878/539/5/1108785395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.159779,
-    "geom:area_square_m":9118804548.92897,
+    "geom:area_square_m":9118804158.706739,
     "geom:bbox":"68.637765,50.039407,70.853975,51.11532",
     "geom:latitude":50.515859,
     "geom:longitude":69.919712,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.AM.KR",
         "wd:id":"Q2565586"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837948,
-    "wof:geomhash":"f6bb69e2e0e76698fd2b74d8922dce4d",
+    "wof:geomhash":"3dfa12431300c3ae4162413ea98913a9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785395,
-    "wof:lastmodified":1690938423,
+    "wof:lastmodified":1695886686,
     "wof:name":"Korgalzhynskiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/539/7/1108785397.geojson
+++ b/data/110/878/539/7/1108785397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.825423,
-    "geom:area_square_m":6230337879.743584,
+    "geom:area_square_m":6230337668.692148,
     "geom:bbox":"67.737693,51.986333,69.502812,52.827546",
     "geom:latitude":52.379387,
     "geom:longitude":68.682738,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.AM.SA",
         "wd:id":"Q2565597"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837949,
-    "wof:geomhash":"edd955fe0a51c90e4594c169213d5680",
+    "wof:geomhash":"6f5ef35adfd56281fc5890c943f2a451",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785397,
-    "wof:lastmodified":1690938422,
+    "wof:lastmodified":1695886686,
     "wof:name":"Sandyktauskiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/539/9/1108785399.geojson
+++ b/data/110/878/539/9/1108785399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.221154,
-    "geom:area_square_m":60617303305.328941,
+    "geom:area_square_m":60617303380.619186,
     "geom:bbox":"54.881238,45.177413,58.143459,49.015635",
     "geom:latitude":47.237773,
     "geom:longitude":56.557088,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.AT.BA",
         "wd:id":"Q2115182"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837951,
-    "wof:geomhash":"6372f78c09ea3e783605bae9d0439b56",
+    "wof:geomhash":"b23badfd3d0955fa0e82c475266fb38e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785399,
-    "wof:lastmodified":1690938422,
+    "wof:lastmodified":1695886686,
     "wof:name":"Bayganinskiy",
     "wof:parent_id":85672877,
     "wof:placetype":"county",

--- a/data/110/878/540/1/1108785401.geojson
+++ b/data/110/878/540/1/1108785401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.410403,
-    "geom:area_square_m":11381874621.004457,
+    "geom:area_square_m":11381874163.721512,
     "geom:bbox":"53.619211,48.638563,55.51175,49.814121",
     "geom:latitude":49.258945,
     "geom:longitude":54.586121,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.AT.UI",
         "wd:id":"Q2550333"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837952,
-    "wof:geomhash":"8b101bba3a002b61777336c537b0f7c0",
+    "wof:geomhash":"922df8f6d933ebccaea613b11698449f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785401,
-    "wof:lastmodified":1690938438,
+    "wof:lastmodified":1695886694,
     "wof:name":"Uilskiy",
     "wof:parent_id":85672877,
     "wof:placetype":"county",

--- a/data/110/878/540/3/1108785403.geojson
+++ b/data/110/878/540/3/1108785403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.27838,
-    "geom:area_square_m":37023687030.554741,
+    "geom:area_square_m":37023686624.733917,
     "geom:bbox":"73.94134,44.284639,77.181856,46.781777",
     "geom:latitude":45.582988,
     "geom:longitude":75.357109,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.AA.BA",
         "wd:id":"Q2565663"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837953,
-    "wof:geomhash":"37d14d21b3c1030e7f95be934856fcf2",
+    "wof:geomhash":"5215082b6b9288695280f057de3e9d61",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785403,
-    "wof:lastmodified":1690938439,
+    "wof:lastmodified":1695886694,
     "wof:name":"Balkhashskiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/540/5/1108785405.geojson
+++ b/data/110/878/540/5/1108785405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.809142,
-    "geom:area_square_m":7101717540.911468,
+    "geom:area_square_m":7101717094.15798,
     "geom:bbox":"76.733326,44.426511,78.551975,45.103042",
     "geom:latitude":44.780882,
     "geom:longitude":77.611691,
@@ -129,9 +129,10 @@
         "hasc:id":"KZ.AA.KO",
         "wd:id":"Q2550398"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837954,
-    "wof:geomhash":"9aeb36e2ab78a3c4955322bad8446dc5",
+    "wof:geomhash":"3ff82265e8e4306ca69a180f54f5ae7a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108785405,
-    "wof:lastmodified":1690938439,
+    "wof:lastmodified":1695886695,
     "wof:name":"Koksuskiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/540/7/1108785407.geojson
+++ b/data/110/878/540/7/1108785407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.461828,
-    "geom:area_square_m":12662584093.817299,
+    "geom:area_square_m":12662583542.992641,
     "geom:bbox":"77.788467,44.934938,80.229021,46.255763",
     "geom:latitude":45.52987,
     "geom:longitude":79.036837,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.AA.AK",
         "wd:id":"Q2737272"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837957,
-    "wof:geomhash":"4ee6e295904b90552872677abcdaedcd",
+    "wof:geomhash":"ae9bb4eb2475b3ae4f284ce4c3661d1e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785407,
-    "wof:lastmodified":1690938438,
+    "wof:lastmodified":1695886694,
     "wof:name":"Aksuskiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/540/9/1108785409.geojson
+++ b/data/110/878/540/9/1108785409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.164109,
-    "geom:area_square_m":10308246059.624184,
+    "geom:area_square_m":10308246696.11561,
     "geom:bbox":"78.858062,43.757811,80.52506,44.841996",
     "geom:latitude":44.263761,
     "geom:longitude":79.769199,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.AA.PA",
         "wd:id":"Q2556261"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837958,
-    "wof:geomhash":"11c1607e8ec58e3c479a4ef9c138cbf4",
+    "wof:geomhash":"62fe95dcab10b45305cf592bda1c0c18",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785409,
-    "wof:lastmodified":1690938438,
+    "wof:lastmodified":1695886694,
     "wof:name":"Panfilovskiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/541/3/1108785413.geojson
+++ b/data/110/878/541/3/1108785413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.702729,
-    "geom:area_square_m":23227696914.472122,
+    "geom:area_square_m":23227696217.958977,
     "geom:bbox":"79.462041,45.124556,82.587726,46.909536",
     "geom:latitude":45.96904,
     "geom:longitude":80.953007,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AA.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837959,
-    "wof:geomhash":"f9c16aaf707581324ba77ea165afb015",
+    "wof:geomhash":"ad60b7c702112f8a6f810e56056a768c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785413,
-    "wof:lastmodified":1627522309,
+    "wof:lastmodified":1695886772,
     "wof:name":"Alakolskiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/541/5/1108785415.geojson
+++ b/data/110/878/541/5/1108785415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.704999,
-    "geom:area_square_m":23326665313.873119,
+    "geom:area_square_m":23326666335.213501,
     "geom:bbox":"76.176966,44.969601,78.469778,46.635047",
     "geom:latitude":45.779391,
     "geom:longitude":77.18237,
@@ -132,9 +132,10 @@
         "hasc:id":"KZ.AA.KT",
         "wd:id":"Q2550342"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837960,
-    "wof:geomhash":"94c1283e50251ad2173d869684b1778d",
+    "wof:geomhash":"b599f32b36e97940b47147d8b4ff737c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108785415,
-    "wof:lastmodified":1690938440,
+    "wof:lastmodified":1695886695,
     "wof:name":"Karatal`skiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/541/7/1108785417.geojson
+++ b/data/110/878/541/7/1108785417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.828204,
-    "geom:area_square_m":24141568341.124405,
+    "geom:area_square_m":24141567968.722603,
     "geom:bbox":"77.465757,45.027658,80.806039,47.289027",
     "geom:latitude":46.341594,
     "geom:longitude":78.988819,
@@ -129,9 +129,10 @@
         "hasc:id":"KZ.AA.SA",
         "wd:id":"Q2556173"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837961,
-    "wof:geomhash":"a5d4dd2b52b1cb9a5885330410b6c7d6",
+    "wof:geomhash":"2f818f21b4eb2927b67eb910f477cf8c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108785417,
-    "wof:lastmodified":1690938439,
+    "wof:lastmodified":1695886695,
     "wof:name":"Sarkandskiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/541/9/1108785419.geojson
+++ b/data/110/878/541/9/1108785419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.222584,
-    "geom:area_square_m":2007148614.959561,
+    "geom:area_square_m":2007149037.977765,
     "geom:bbox":"76.280311,42.904121,77.111784,43.600951",
     "geom:latitude":43.175006,
     "geom:longitude":76.655801,
@@ -135,9 +135,10 @@
         "hasc:id":"KZ.AA.KS",
         "wd:id":"Q2550378"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837963,
-    "wof:geomhash":"177ce4644666d226977d9940226ee082",
+    "wof:geomhash":"9e1d082467e7792fb76b64dfe07c6ebd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108785419,
-    "wof:lastmodified":1690938439,
+    "wof:lastmodified":1695886695,
     "wof:name":"Karasayskiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/542/1/1108785421.geojson
+++ b/data/110/878/542/1/1108785421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.293339,
-    "geom:area_square_m":2641651750.624557,
+    "geom:area_square_m":2641651040.330844,
     "geom:bbox":"77.006799,42.970455,78.29015,43.776327",
     "geom:latitude":43.2564,
     "geom:longitude":77.408691,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.AA.TG",
         "wd:id":"Q2556049"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837964,
-    "wof:geomhash":"a645e6cd75ade2fabf62d7a4a307cd4c",
+    "wof:geomhash":"2701b8b8322ae29f75603d1e0f7a0430",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785421,
-    "wof:lastmodified":1690938419,
+    "wof:lastmodified":1695886684,
     "wof:name":"Talgarskiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/542/3/1108785423.geojson
+++ b/data/110/878/542/3/1108785423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.294079,
-    "geom:area_square_m":11448166817.039478,
+    "geom:area_square_m":11448167455.116152,
     "geom:bbox":"76.898843,43.828322,79.999625,44.910719",
     "geom:latitude":44.319999,
     "geom:longitude":78.417868,
@@ -132,9 +132,10 @@
         "hasc:id":"KZ.AA.KE",
         "wd:id":"Q2556317"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837965,
-    "wof:geomhash":"7ccbc686b7ce6cd1f7b665a6232f2f89",
+    "wof:geomhash":"2c1be4d08d64cfe526fe210bc664d652",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108785423,
-    "wof:lastmodified":1690938419,
+    "wof:lastmodified":1695886684,
     "wof:name":"Kerbulakskiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/542/5/1108785425.geojson
+++ b/data/110/878/542/5/1108785425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.971367,
-    "geom:area_square_m":8705519807.897083,
+    "geom:area_square_m":8705519559.81431,
     "geom:bbox":"79.000558,43.136416,80.756702,43.979782",
     "geom:latitude":43.548405,
     "geom:longitude":79.812197,
@@ -135,9 +135,10 @@
         "hasc:id":"KZ.AA.UY",
         "wd:id":"Q2360606"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837966,
-    "wof:geomhash":"a9963289d96919b241263e128c2927cd",
+    "wof:geomhash":"6f1d01715b42f2ef2dcbc96af0244c3c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108785425,
-    "wof:lastmodified":1690938420,
+    "wof:lastmodified":1695886684,
     "wof:name":"Uygurskiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/542/7/1108785427.geojson
+++ b/data/110/878/542/7/1108785427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.97032,
-    "geom:area_square_m":8702733215.945055,
+    "geom:area_square_m":8702733296.643967,
     "geom:bbox":"77.139681,43.123181,79.130974,43.849993",
     "geom:latitude":43.502899,
     "geom:longitude":78.161884,
@@ -129,9 +129,10 @@
         "hasc:id":"KZ.AA.EN",
         "wd:id":"Q2556225"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837967,
-    "wof:geomhash":"d6540e3580a0506cb70b6b470756d399",
+    "wof:geomhash":"b4f0a308705928e4a83b1f1ede46019b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108785427,
-    "wof:lastmodified":1690938419,
+    "wof:lastmodified":1695886683,
     "wof:name":"Enbekshikazakhskiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/543/1/1108785431.geojson
+++ b/data/110/878/543/1/1108785431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.476728,
-    "geom:area_square_m":4241345905.463778,
+    "geom:area_square_m":4241346058.679416,
     "geom:bbox":"76.745873,43.701087,78.496799,44.373796",
     "geom:latitude":43.986382,
     "geom:longitude":77.421527,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AA.TG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837968,
-    "wof:geomhash":"c5c732797b6acbee189df15f8f36116c",
+    "wof:geomhash":"66b775bf85773cbf6f82e0e37c4c3f67",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785431,
-    "wof:lastmodified":1627522313,
+    "wof:lastmodified":1695886776,
     "wof:name":"Talgarskiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/543/3/1108785433.geojson
+++ b/data/110/878/543/3/1108785433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.876371,
-    "geom:area_square_m":7788724813.239486,
+    "geom:area_square_m":7788725361.48876,
     "geom:bbox":"75.987942,43.337602,77.156829,44.770254",
     "geom:latitude":44.047605,
     "geom:longitude":76.555851,
@@ -135,9 +135,10 @@
         "hasc:id":"KZ.AA.IL",
         "wd:id":"Q2466404"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837969,
-    "wof:geomhash":"45edacd0a951caf62d93c51fabd8e86b",
+    "wof:geomhash":"8556da9249431630c9d1945b23bcbd48",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108785433,
-    "wof:lastmodified":1690938416,
+    "wof:lastmodified":1695886683,
     "wof:name":"Iliyskiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/543/5/1108785435.geojson
+++ b/data/110/878/543/5/1108785435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076857,
-    "geom:area_square_m":692604991.469156,
+    "geom:area_square_m":692604991.469177,
     "geom:bbox":"76.743077,43.033467,77.147546,43.400639",
     "geom:latitude":43.214961,
     "geom:longitude":76.941006,
@@ -557,7 +557,7 @@
     ],
     "wof:country":"KZ",
     "wof:created":1481837970,
-    "wof:geomhash":"25803b9a6e9b5c7fe921131bc7bc2491",
+    "wof:geomhash":"a37cb9df12b383a9166f9bd7119e0d4a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -567,7 +567,7 @@
         }
     ],
     "wof:id":1108785435,
-    "wof:lastmodified":1587163113,
+    "wof:lastmodified":1695886288,
     "wof:name":"Almaty",
     "wof:parent_id":85672937,
     "wof:placetype":"county",

--- a/data/110/878/543/7/1108785437.geojson
+++ b/data/110/878/543/7/1108785437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.599284,
-    "geom:area_square_m":4599016120.304784,
+    "geom:area_square_m":4599015770.300476,
     "geom:bbox":"69.966724,51.269615,71.994127,51.852645",
     "geom:latitude":51.637886,
     "geom:longitude":71.003691,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.AM.SD",
         "wd:id":"Q2556281"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837971,
-    "wof:geomhash":"1c5b72cb969fbaa0739b064259cb95f6",
+    "wof:geomhash":"f4ede0a37c70697737ab7ef5d2647a3d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785437,
-    "wof:lastmodified":1690938416,
+    "wof:lastmodified":1695886683,
     "wof:name":"Shortandinskiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/543/9/1108785439.geojson
+++ b/data/110/878/543/9/1108785439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090696,
-    "geom:area_square_m":703577514.676264,
+    "geom:area_square_m":703577572.013518,
     "geom:bbox":"71.220936,50.999912,71.728067,51.301212",
     "geom:latitude":51.143772,
     "geom:longitude":71.437183,
@@ -59,9 +59,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AM.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837972,
-    "wof:geomhash":"3bbc456cb98bbf9bdf0d047e1e148a89",
+    "wof:geomhash":"843371c09ad0338bf9f616e12e8b3d7e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108785439,
-    "wof:lastmodified":1627522312,
+    "wof:lastmodified":1695886775,
     "wof:name":"Tselinogradskiy",
     "wof:parent_id":85672941,
     "wof:placetype":"county",

--- a/data/110/878/544/1/1108785441.geojson
+++ b/data/110/878/544/1/1108785441.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.199271,
-    "geom:area_square_m":1536678952.340309,
+    "geom:area_square_m":1536679245.535959,
     "geom:bbox":"71.437811,51.07853,72.106668,51.65875",
     "geom:latitude":51.417068,
     "geom:longitude":71.760787,
@@ -111,9 +111,10 @@
         "hasc:id":"KZ.AM.TS",
         "wd:id":"Q2224859"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837973,
-    "wof:geomhash":"ce0e6b3f9aa7658c03b8e9d10dd71f01",
+    "wof:geomhash":"8260d04cce7c519676cce3f1c393f970",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108785441,
-    "wof:lastmodified":1690938417,
+    "wof:lastmodified":1695886683,
     "wof:name":"Tselinogradskiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/544/3/1108785443.geojson
+++ b/data/110/878/544/3/1108785443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.769011,
-    "geom:area_square_m":5992560251.478833,
+    "geom:area_square_m":5992560240.409702,
     "geom:bbox":"71.590551,50.412743,73.172831,51.43026",
     "geom:latitude":50.9347,
     "geom:longitude":72.215688,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AM.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837974,
-    "wof:geomhash":"c84a1f1950c852c8bf5e9f2c4630e8c1",
+    "wof:geomhash":"5ea1a43da49344f758bce49fdd93ee6c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785443,
-    "wof:lastmodified":1627522309,
+    "wof:lastmodified":1695886773,
     "wof:name":"Arshalynskiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/544/5/1108785445.geojson
+++ b/data/110/878/544/5/1108785445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.390902,
-    "geom:area_square_m":11443611287.614902,
+    "geom:area_square_m":11443611649.391832,
     "geom:bbox":"49.975313,47.83784,52.813161,48.729841",
     "geom:latitude":48.288749,
     "geom:longitude":51.412621,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.AR.IN",
         "wd:id":"Q2737298"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837976,
-    "wof:geomhash":"330fbb101a0d99724dc0fc8675ca2ee4",
+    "wof:geomhash":"cb9ebe302dbde89c1bdbf8163f57edaa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785445,
-    "wof:lastmodified":1690938417,
+    "wof:lastmodified":1695886683,
     "wof:name":"Inderskiy",
     "wof:parent_id":85672889,
     "wof:placetype":"county",

--- a/data/110/878/544/9/1108785449.geojson
+++ b/data/110/878/544/9/1108785449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.760685,
-    "geom:area_square_m":14731756217.509335,
+    "geom:area_square_m":14731756178.303516,
     "geom:bbox":"49.389701,46.58139,51.391425,48.094109",
     "geom:latitude":47.415668,
     "geom:longitude":50.371673,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.AR.IS",
         "wd:id":"Q2737292"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837977,
-    "wof:geomhash":"67f8d8e2a288642fe41f0b2ff6bec4f4",
+    "wof:geomhash":"e4e380899bb95761a057be6b88d81024",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785449,
-    "wof:lastmodified":1690938417,
+    "wof:lastmodified":1695886683,
     "wof:name":"Isatayskiy",
     "wof:parent_id":85672889,
     "wof:placetype":"county",

--- a/data/110/878/545/1/1108785451.geojson
+++ b/data/110/878/545/1/1108785451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.438099,
-    "geom:area_square_m":3690812722.715376,
+    "geom:area_square_m":3690812722.71536,
     "geom:bbox":"51.542331696,46.725223541,52.7556612375,47.4744197675",
     "geom:latitude":47.053188,
     "geom:longitude":52.157925,
@@ -242,9 +242,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AR.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837978,
-    "wof:geomhash":"3db5c635ba1490fdd89c65a87dd26201",
+    "wof:geomhash":"6458349fc7a9cb37ca00129bf45a5f16",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -254,7 +255,7 @@
         }
     ],
     "wof:id":1108785451,
-    "wof:lastmodified":1566591769,
+    "wof:lastmodified":1695886684,
     "wof:name":"Atyrau",
     "wof:parent_id":85672889,
     "wof:placetype":"county",

--- a/data/110/878/545/3/1108785453.geojson
+++ b/data/110/878/545/3/1108785453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.027357,
-    "geom:area_square_m":24912944450.169395,
+    "geom:area_square_m":24912944888.417934,
     "geom:bbox":"52.347244,47.281484,55.122705,49.239258",
     "geom:latitude":48.2765,
     "geom:longitude":53.681996,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AR.KZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837979,
-    "wof:geomhash":"599dd974a997b18fc2c8a6fab514af4e",
+    "wof:geomhash":"21346ff79fdf598c0c5fc472ea4c39d2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785453,
-    "wof:lastmodified":1627522311,
+    "wof:lastmodified":1695886775,
     "wof:name":"Kzylkoginskiy",
     "wof:parent_id":85672889,
     "wof:placetype":"county",

--- a/data/110/878/545/5/1108785455.geojson
+++ b/data/110/878/545/5/1108785455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.556894,
-    "geom:area_square_m":4663886775.607224,
+    "geom:area_square_m":4663886987.984787,
     "geom:bbox":"52.353337,46.983322,53.83653,47.740247",
     "geom:latitude":47.36759,
     "geom:longitude":53.120557,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.AR.MK",
         "wd:id":"Q2550418"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837980,
-    "wof:geomhash":"d8d5f5d84785c569583eaa67862a82a7",
+    "wof:geomhash":"9b924df6624c4263b4ed4dbaebf0ef78",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785455,
-    "wof:lastmodified":1690938418,
+    "wof:lastmodified":1695886684,
     "wof:name":"Makatskiy",
     "wof:parent_id":85672889,
     "wof:placetype":"county",

--- a/data/110/878/545/7/1108785457.geojson
+++ b/data/110/878/545/7/1108785457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.16777,
-    "geom:area_square_m":9728030367.979782,
+    "geom:area_square_m":9728030150.558769,
     "geom:bbox":"50.625957,46.897388,52.706604,48.184248",
     "geom:latitude":47.646055,
     "geom:longitude":51.801199,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.AR.MB",
         "wd:id":"Q2556162"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837981,
-    "wof:geomhash":"39653bd21c1e9ec8dcbee2d6f42a3228",
+    "wof:geomhash":"7544cccaafed121f4042dfcab4f9b2a4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785457,
-    "wof:lastmodified":1690938418,
+    "wof:lastmodified":1695886684,
     "wof:name":"Makhambetskiy",
     "wof:parent_id":85672889,
     "wof:placetype":"county",

--- a/data/110/878/545/9/1108785459.geojson
+++ b/data/110/878/545/9/1108785459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.670246,
-    "geom:area_square_m":47061765897.92511,
+    "geom:area_square_m":47061766601.898788,
     "geom:bbox":"76.790059,46.787103,81.672672,48.860131",
     "geom:latitude":47.837239,
     "geom:longitude":79.015916,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.EK.AY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837982,
-    "wof:geomhash":"3d0fd4a845766b21ba9574575f5357bf",
+    "wof:geomhash":"9dc5a59a99a28bf57d4fedf751f62163",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785459,
-    "wof:lastmodified":1627522308,
+    "wof:lastmodified":1695886772,
     "wof:name":"Ayagozskiy",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/546/1/1108785461.geojson
+++ b/data/110/878/546/1/1108785461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.392657,
-    "geom:area_square_m":11113888873.567949,
+    "geom:area_square_m":11113888755.465517,
     "geom:bbox":"82.86769,49.29113,85.280687,50.289577",
     "geom:latitude":49.804876,
     "geom:longitude":84.14451,
@@ -136,9 +136,10 @@
         "hasc:id":"KZ.EK.ZY",
         "wd:id":"Q2664367"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837983,
-    "wof:geomhash":"cfe9df6fe4f23be57a01d5a7bbe4d54e",
+    "wof:geomhash":"00d403f670c718209d0c3a1ce3e93b83",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1108785461,
-    "wof:lastmodified":1690938441,
+    "wof:lastmodified":1695886661,
     "wof:name":"Zyryanovsk",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/546/3/1108785463.geojson
+++ b/data/110/878/546/3/1108785463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.750283,
-    "geom:area_square_m":14262627961.716827,
+    "geom:area_square_m":14262627411.751516,
     "geom:bbox":"81.531205,48.137497,84.235593,49.477222",
     "geom:latitude":48.775012,
     "geom:longitude":82.903201,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.EK.KO",
         "wd:id":"Q2550775"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837984,
-    "wof:geomhash":"9f3daf91d9da6e10a7178b875dd81295",
+    "wof:geomhash":"14abf0b79440169dccfc876b5a93791d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785463,
-    "wof:lastmodified":1690938441,
+    "wof:lastmodified":1695886696,
     "wof:name":"Kokpektinskiy",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/546/7/1108785467.geojson
+++ b/data/110/878/546/7/1108785467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.722101,
-    "geom:area_square_m":21990303220.385006,
+    "geom:area_square_m":21990304143.47736,
     "geom:bbox":"80.108999,48.250149,82.543908,50.241481",
     "geom:latitude":49.205989,
     "geom:longitude":81.120045,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.EK.ZH",
         "wd:id":"Q2726381"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837985,
-    "wof:geomhash":"6e5406a6088e7ca72f2cba0e119f6268",
+    "wof:geomhash":"6a08778fb4b6e90a304a7c0d19663497",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785467,
-    "wof:lastmodified":1690938440,
+    "wof:lastmodified":1695886696,
     "wof:name":"Zharminskiy",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/546/9/1108785469.geojson
+++ b/data/110/878/546/9/1108785469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.775108,
-    "geom:area_square_m":23095926896.856636,
+    "geom:area_square_m":23095926337.33844,
     "geom:bbox":"81.397145,46.966942,84.405716,48.498767",
     "geom:latitude":47.695275,
     "geom:longitude":82.866496,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.EK.TA",
         "wd:id":"Q613774"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837986,
-    "wof:geomhash":"3451b5a122f19dbdea4975e9c7cd9ea8",
+    "wof:geomhash":"3d47ce553e53c5178ecec5b84cd92588",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785469,
-    "wof:lastmodified":1690938440,
+    "wof:lastmodified":1695886695,
     "wof:name":"Tarbagatayskiy",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/547/1/1108785471.geojson
+++ b/data/110/878/547/1/1108785471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.834023,
-    "geom:area_square_m":23220635558.353325,
+    "geom:area_square_m":23220636690.245029,
     "geom:bbox":"83.300147,47.776135,86.819216,49.075784",
     "geom:latitude":48.498684,
     "geom:longitude":84.850386,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.EK.KU",
         "wd:id":"Q2550784"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837987,
-    "wof:geomhash":"6b3c073f16f14ee41eee268429f0af68",
+    "wof:geomhash":"d1f5c77c8cbd1b37162ad46fd38b498c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785471,
-    "wof:lastmodified":1690938437,
+    "wof:lastmodified":1695886693,
     "wof:name":"Kurchumskiy",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/547/3/1108785473.geojson
+++ b/data/110/878/547/3/1108785473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.21912,
-    "geom:area_square_m":9751136349.349081,
+    "geom:area_square_m":9751136442.469484,
     "geom:bbox":"81.119854,49.12713,83.660311,50.307512",
     "geom:latitude":49.694415,
     "geom:longitude":82.402124,
@@ -105,9 +105,10 @@
         "hasc:id":"KZ.EK.UL",
         "wd:id":"Q2550757"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837989,
-    "wof:geomhash":"fece31804498565173c5e8759ed4f5e7",
+    "wof:geomhash":"a29c36dd470d097e6f59d56eb75242dd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108785473,
-    "wof:lastmodified":1690938437,
+    "wof:lastmodified":1695886694,
     "wof:name":"Ulanskiy",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/547/5/1108785475.geojson
+++ b/data/110/878/547/5/1108785475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073622,
-    "geom:area_square_m":586631241.877808,
+    "geom:area_square_m":586630899.683023,
     "geom:bbox":"82.469344,49.728488,82.965957,50.036767",
     "geom:latitude":49.878946,
     "geom:longitude":82.702858,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.EK.UL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837990,
-    "wof:geomhash":"b76238c0b352a58efac27f6a6a3db69d",
+    "wof:geomhash":"2e15d84c950dbbcacf1f999a11deb144",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785475,
-    "wof:lastmodified":1627522314,
+    "wof:lastmodified":1695886778,
     "wof:name":"Ulanskiy",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/547/7/1108785477.geojson
+++ b/data/110/878/547/7/1108785477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120236,
-    "geom:area_square_m":1076818689.070345,
+    "geom:area_square_m":1076818408.211838,
     "geom:bbox":"71.479988,43.391657,71.943435,43.820886",
     "geom:latitude":43.590912,
     "geom:longitude":71.739074,
@@ -74,7 +74,7 @@
     "wof:concordances":{},
     "wof:country":"KZ",
     "wof:created":1481837991,
-    "wof:geomhash":"1cad0306cfc8a4f01bde71661689b840",
+    "wof:geomhash":"d5e3743ea71c3cc33e6ae93587f007bb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +84,7 @@
         }
     ],
     "wof:id":1108785477,
-    "wof:lastmodified":1636495698,
+    "wof:lastmodified":1695886661,
     "wof:name":"Zhambyl",
     "wof:parent_id":85672931,
     "wof:placetype":"county",

--- a/data/110/878/547/9/1108785479.geojson
+++ b/data/110/878/547/9/1108785479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085243,
-    "geom:area_square_m":759908877.025069,
+    "geom:area_square_m":759908895.156788,
     "geom:bbox":"71.560332,43.685688,71.960114,44.026141",
     "geom:latitude":43.867656,
     "geom:longitude":71.748018,
@@ -62,7 +62,7 @@
     "wof:concordances":{},
     "wof:country":"KZ",
     "wof:created":1481837992,
-    "wof:geomhash":"3ee442773b5a9c367a9f00dd202ea3bd",
+    "wof:geomhash":"f48287a22ae065e64b911808d2133a9b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1108785479,
-    "wof:lastmodified":1627522311,
+    "wof:lastmodified":1695886775,
     "wof:name":"Zhualy",
     "wof:parent_id":85672931,
     "wof:placetype":"county",

--- a/data/110/878/548/1/1108785481.geojson
+++ b/data/110/878/548/1/1108785481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.126897,
-    "geom:area_square_m":18944913763.547192,
+    "geom:area_square_m":18944912825.541019,
     "geom:bbox":"74.409524,42.860756,76.531548,44.863079",
     "geom:latitude":43.913657,
     "geom:longitude":75.640559,
@@ -59,9 +59,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AA.ZH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837993,
-    "wof:geomhash":"c57d7bf809d54fb99a6489ddf632ab79",
+    "wof:geomhash":"12f0238c920bf11d3c02a6e3e9850fa0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108785481,
-    "wof:lastmodified":1627522314,
+    "wof:lastmodified":1695886778,
     "wof:name":"Zhambylskiy",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/548/5/1108785485.geojson
+++ b/data/110/878/548/5/1108785485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.688679,
-    "geom:area_square_m":49790716343.084923,
+    "geom:area_square_m":49790717540.072334,
     "geom:bbox":"70.74055,43.822195,74.52371,46.002214",
     "geom:latitude":44.937559,
     "geom:longitude":72.71785,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.ZM.MO",
         "wd:id":"Q2549644"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837994,
-    "wof:geomhash":"918929905392eb1345ff4db22aa1be53",
+    "wof:geomhash":"9acde94a7ad9c4f36042493fd68935e8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785485,
-    "wof:lastmodified":1690938443,
+    "wof:lastmodified":1695886697,
     "wof:name":"Moyynkumskiy",
     "wof:parent_id":85672931,
     "wof:placetype":"county",

--- a/data/110/878/548/7/1108785487.geojson
+++ b/data/110/878/548/7/1108785487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.536077,
-    "geom:area_square_m":4819744590.706914,
+    "geom:area_square_m":4819744877.910401,
     "geom:bbox":"71.11989,42.775571,72.244748,44.040426",
     "geom:latitude":43.355124,
     "geom:longitude":71.706515,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.ZM.BA",
         "wd:id":"Q2549636"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837995,
-    "wof:geomhash":"da0398af193b47c88f4dcd0ac9d2a83d",
+    "wof:geomhash":"5eff3d68809071ed4d41674f0d152927",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785487,
-    "wof:lastmodified":1690938443,
+    "wof:lastmodified":1695886697,
     "wof:name":"Bayzakskiy",
     "wof:parent_id":85672931,
     "wof:placetype":"county",

--- a/data/110/878/548/9/1108785489.geojson
+++ b/data/110/878/548/9/1108785489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.054872,
-    "geom:area_square_m":9516138374.447411,
+    "geom:area_square_m":9516138285.088051,
     "geom:bbox":"71.815203,42.530043,73.243543,44.007636",
     "geom:latitude":43.149791,
     "geom:longitude":72.51624,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.ZM.LU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837996,
-    "wof:geomhash":"009c88cf18bb9770279f240362b4f1bf",
+    "wof:geomhash":"ba2c1133dd74df4c51abdb2ae8ad1fab",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785489,
-    "wof:lastmodified":1627522312,
+    "wof:lastmodified":1695886776,
     "wof:name":"Lugovskoy",
     "wof:parent_id":85672931,
     "wof:placetype":"county",

--- a/data/110/878/549/1/1108785491.geojson
+++ b/data/110/878/549/1/1108785491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.78494,
-    "geom:area_square_m":14131287638.900862,
+    "geom:area_square_m":14131287499.048634,
     "geom:bbox":"54.371459,49.40551,56.340697,51.039959",
     "geom:latitude":50.187873,
     "geom:longitude":55.333787,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.AT.KB",
         "wd:id":"Q2737287"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837998,
-    "wof:geomhash":"ed255023d1f7f86f26522cb8ee27c5c8",
+    "wof:geomhash":"766d63e311f38dc933bcf4d9e4f4ee4b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785491,
-    "wof:lastmodified":1690938435,
+    "wof:lastmodified":1695886692,
     "wof:name":"Khobdinskiy",
     "wof:parent_id":85672877,
     "wof:placetype":"county",

--- a/data/110/878/549/3/1108785493.geojson
+++ b/data/110/878/549/3/1108785493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.230648,
-    "geom:area_square_m":9848699232.620455,
+    "geom:area_square_m":9848699585.374336,
     "geom:bbox":"52.589997,49.088684,54.57933,50.2729",
     "geom:latitude":49.667949,
     "geom:longitude":53.511062,
@@ -114,9 +114,10 @@
         "hasc:id":"KZ.WK.KR",
         "wd:id":"Q595124"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481837999,
-    "wof:geomhash":"db6f8fc8cc91635dd966e3c71b55ffd5",
+    "wof:geomhash":"9c8a01aa6c996c441f465aa118882c9d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108785493,
-    "wof:lastmodified":1690938435,
+    "wof:lastmodified":1695886693,
     "wof:name":"Karatobinskiy",
     "wof:parent_id":85672893,
     "wof:placetype":"county",

--- a/data/110/878/549/5/1108785495.geojson
+++ b/data/110/878/549/5/1108785495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.505019,
-    "geom:area_square_m":11883049023.934378,
+    "geom:area_square_m":11883048899.157383,
     "geom:bbox":"51.832826,49.597931,53.683428,50.958113",
     "geom:latitude":50.316571,
     "geom:longitude":52.679291,
@@ -117,9 +117,10 @@
         "hasc:id":"KZ.WK.SY",
         "wd:id":"Q2736622"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838000,
-    "wof:geomhash":"e4708c61a557f9bdff7663593ff5bc76",
+    "wof:geomhash":"c9dcff991fc66fb6864eebbea38927b7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108785495,
-    "wof:lastmodified":1690938436,
+    "wof:lastmodified":1695886693,
     "wof:name":"Syrymskiy",
     "wof:parent_id":85672893,
     "wof:placetype":"county",

--- a/data/110/878/549/7/1108785497.geojson
+++ b/data/110/878/549/7/1108785497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.486249,
-    "geom:area_square_m":11566251724.22496,
+    "geom:area_square_m":11566251551.375465,
     "geom:bbox":"65.440618,50.379433,67.939159,51.741927",
     "geom:latitude":50.996423,
     "geom:longitude":66.679653,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.AM.ZR",
         "wd:id":"Q2556274"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838001,
-    "wof:geomhash":"4963a47aadd45043a33a5604e5899c38",
+    "wof:geomhash":"6ef304c5fe943873b12cf254c0cf602f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785497,
-    "wof:lastmodified":1690938435,
+    "wof:lastmodified":1695886692,
     "wof:name":"Zharkainskiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/549/9/1108785499.geojson
+++ b/data/110/878/549/9/1108785499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.880914,
-    "geom:area_square_m":47010601126.346115,
+    "geom:area_square_m":47010600816.654953,
     "geom:bbox":"67.402867,48.622855,72.022845,50.803191",
     "geom:latitude":49.722185,
     "geom:longitude":69.686688,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.QG.NU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838002,
-    "wof:geomhash":"e42081c0b1792a0d060c418d4d6ed922",
+    "wof:geomhash":"7a4c88252c241a7b0c7a18d894ac4449",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785499,
-    "wof:lastmodified":1627522312,
+    "wof:lastmodified":1695886776,
     "wof:name":"Nurinskiy",
     "wof:parent_id":85672905,
     "wof:placetype":"county",

--- a/data/110/878/550/3/1108785503.geojson
+++ b/data/110/878/550/3/1108785503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.679322,
-    "geom:area_square_m":5290592964.404658,
+    "geom:area_square_m":5290592668.534255,
     "geom:bbox":"68.557318,50.557611,70.199949,51.426334",
     "geom:latitude":50.961709,
     "geom:longitude":69.294623,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.AM.EG",
         "wd:id":"Q2565628"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838003,
-    "wof:geomhash":"0a81ab0100c014a8870c64de896d0d47",
+    "wof:geomhash":"cc5cd6fd98dc11eb33d7825e6397b9b1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785503,
-    "wof:lastmodified":1690938412,
+    "wof:lastmodified":1695886680,
     "wof:name":"Egindykol`skiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/550/5/1108785505.geojson
+++ b/data/110/878/550/5/1108785505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.843616,
-    "geom:area_square_m":57198081349.754707,
+    "geom:area_square_m":57198079704.605499,
     "geom:bbox":"73.285276,45.995,77.679214,48.921544",
     "geom:latitude":47.47063,
     "geom:longitude":75.449132,
@@ -108,9 +108,10 @@
         "hasc:id":"KZ.PA.AT",
         "wd:id":"Q612211"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838004,
-    "wof:geomhash":"6163c8f27e5140a101ac602fd0c19350",
+    "wof:geomhash":"d893fe751f11b8d3172ff91e720d2bc6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108785505,
-    "wof:lastmodified":1690938412,
+    "wof:lastmodified":1695886681,
     "wof:name":"Aktogayskiy",
     "wof:parent_id":85672905,
     "wof:placetype":"county",

--- a/data/110/878/550/7/1108785507.geojson
+++ b/data/110/878/550/7/1108785507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.779292,
-    "geom:area_square_m":38386100159.057869,
+    "geom:area_square_m":38386100837.824394,
     "geom:bbox":"73.935348,48.449277,77.706204,50.65904",
     "geom:latitude":49.490817,
     "geom:longitude":75.99998,
@@ -117,9 +117,10 @@
         "hasc:id":"KZ.QG.KK",
         "wd:id":"Q2726421"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838005,
-    "wof:geomhash":"a7af87f029eb8619882b4b6e2339318d",
+    "wof:geomhash":"02eeff42490a8938c77d46711d03ef39",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108785507,
-    "wof:lastmodified":1690938411,
+    "wof:lastmodified":1695886680,
     "wof:name":"Karkaralinskiy",
     "wof:parent_id":85672905,
     "wof:placetype":"county",

--- a/data/110/878/550/9/1108785509.geojson
+++ b/data/110/878/550/9/1108785509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.951537,
-    "geom:area_square_m":66219039960.52858,
+    "geom:area_square_m":66219038374.026978,
     "geom:bbox":"71.266964,45.998698,74.599672,49.430424",
     "geom:latitude":47.656122,
     "geom:longitude":72.873189,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.QG.ST",
         "wd:id":"Q2726493"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838006,
-    "wof:geomhash":"3cb91c1ccc692dd4cbd248ee27ff4c5b",
+    "wof:geomhash":"97ff45b1a9d57c539b6845d65af23759",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785509,
-    "wof:lastmodified":1690938411,
+    "wof:lastmodified":1695886681,
     "wof:name":"Shetskiy",
     "wof:parent_id":85672905,
     "wof:placetype":"county",

--- a/data/110/878/551/1/1108785511.geojson
+++ b/data/110/878/551/1/1108785511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.683255,
-    "geom:area_square_m":32205884246.885933,
+    "geom:area_square_m":32205884326.283348,
     "geom:bbox":"69.07439,43.21858,71.535548,46.002765",
     "geom:latitude":44.992923,
     "geom:longitude":70.320625,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.ZM.SA",
         "wd:id":"Q2321974"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838008,
-    "wof:geomhash":"3588782de129523ae87c7799682315e6",
+    "wof:geomhash":"be062f071b380550ac34b5bcbb3f5db8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785511,
-    "wof:lastmodified":1690938398,
+    "wof:lastmodified":1695886676,
     "wof:name":"Sarysuskiy",
     "wof:parent_id":85672931,
     "wof:placetype":"county",

--- a/data/110/878/551/3/1108785513.geojson
+++ b/data/110/878/551/3/1108785513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.960598,
-    "geom:area_square_m":15148753559.258789,
+    "geom:area_square_m":15148752325.50145,
     "geom:bbox":"63.024892,50.576149,65.513418,52.010466",
     "geom:latitude":51.326952,
     "geom:longitude":64.141697,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.QS.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838009,
-    "wof:geomhash":"4b413db1c4d599541f7553002dc10ca0",
+    "wof:geomhash":"5238cbc6f690c30e471cadd5a99b7791",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785513,
-    "wof:lastmodified":1627522312,
+    "wof:lastmodified":1695886776,
     "wof:name":"Naurzumskiy",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/551/5/1108785515.geojson
+++ b/data/110/878/551/5/1108785515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":14.92374,
-    "geom:area_square_m":124196863907.914566,
+    "geom:area_square_m":124196863565.68132,
     "geom:bbox":"62.69539,45.999615,69.866312,49.936513",
     "geom:latitude":47.692935,
     "geom:longitude":66.666147,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.QG.UL",
         "wd:id":"Q2668108"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838010,
-    "wof:geomhash":"b8ec0584fbeb03ff6a8837fe42f117b2",
+    "wof:geomhash":"74e720f3c596243e97890c94c7ee2221",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785515,
-    "wof:lastmodified":1690938398,
+    "wof:lastmodified":1695886676,
     "wof:name":"Ulytauskiy",
     "wof:parent_id":85672905,
     "wof:placetype":"county",

--- a/data/110/878/551/7/1108785517.geojson
+++ b/data/110/878/551/7/1108785517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.323058,
-    "geom:area_square_m":10487032943.171753,
+    "geom:area_square_m":10487032943.171116,
     "geom:bbox":"65.7167755244,49.5867145982,68.0979238091,50.6687208246",
     "geom:latitude":50.131555,
     "geom:longitude":66.796649,
@@ -158,9 +158,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.QS.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838011,
-    "wof:geomhash":"857ee3e8c59d238ec811bcd941ae50c2",
+    "wof:geomhash":"a3f9e925a10f310e3b5c9209dd307596",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":1108785517,
-    "wof:lastmodified":1566591738,
+    "wof:lastmodified":1695886676,
     "wof:name":"Arkalyk",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/552/1/1108785521.geojson
+++ b/data/110/878/552/1/1108785521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.948944,
-    "geom:area_square_m":7549725133.354109,
+    "geom:area_square_m":7549725345.688389,
     "geom:bbox":"56.177073,49.53779,58.417965,50.448097",
     "geom:latitude":49.952995,
     "geom:longitude":57.059506,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.AT.AL",
         "wd:id":"Q279835"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838012,
-    "wof:geomhash":"8dba743dcc6531f495a263024d85aa8e",
+    "wof:geomhash":"11dfb7f0a6e2c1f123bf3a03e36ff1c4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785521,
-    "wof:lastmodified":1690938424,
+    "wof:lastmodified":1695886687,
     "wof:name":"Alginskiy",
     "wof:parent_id":85672877,
     "wof:placetype":"county",

--- a/data/110/878/552/3/1108785523.geojson
+++ b/data/110/878/552/3/1108785523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.602581,
-    "geom:area_square_m":12688504510.222385,
+    "geom:area_square_m":12688504595.476109,
     "geom:bbox":"57.580895,49.577311,60.044747,50.695852",
     "geom:latitude":50.18468,
     "geom:longitude":58.832402,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.AT.KT",
         "wd:id":"Q2550426"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838013,
-    "wof:geomhash":"e927bafc92d7a364469290b5a96ed996",
+    "wof:geomhash":"f7a3091b307221d7c1f0c045802db67c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785523,
-    "wof:lastmodified":1690938424,
+    "wof:lastmodified":1695886687,
     "wof:name":"Khromtauskiy",
     "wof:parent_id":85672877,
     "wof:placetype":"county",

--- a/data/110/878/552/5/1108785525.geojson
+++ b/data/110/878/552/5/1108785525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.983919,
-    "geom:area_square_m":7500655102.760513,
+    "geom:area_square_m":7500654874.03975,
     "geom:bbox":"59.993083,51.387623,61.73134,52.512487",
     "geom:latitude":51.938023,
     "geom:longitude":61.029827,
@@ -129,9 +129,10 @@
         "hasc:id":"KZ.QS.ZH",
         "wd:id":"Q1378355"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838014,
-    "wof:geomhash":"e89884b5372bf91346e6f8341d20edd5",
+    "wof:geomhash":"3152197230ae6d622df85424fece5768",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108785525,
-    "wof:lastmodified":1690938425,
+    "wof:lastmodified":1695886687,
     "wof:name":"Zhitikarinskiy",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/552/7/1108785527.geojson
+++ b/data/110/878/552/7/1108785527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.706721,
-    "geom:area_square_m":37639203773.437637,
+    "geom:area_square_m":37639204055.800278,
     "geom:bbox":"62.231073,48.172459,65.102237,50.989795",
     "geom:latitude":49.701431,
     "geom:longitude":63.631095,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.QS.DZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838015,
-    "wof:geomhash":"35aef3a7eeb9948547cfc7a849008c86",
+    "wof:geomhash":"fe13c9e614d37428417e0959a8c53aa5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785527,
-    "wof:lastmodified":1627522310,
+    "wof:lastmodified":1695886774,
     "wof:name":"Dzhangil`dinskiy",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/552/9/1108785529.geojson
+++ b/data/110/878/552/9/1108785529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.576296,
-    "geom:area_square_m":12120586384.80245,
+    "geom:area_square_m":12120587028.752411,
     "geom:bbox":"61.45664,50.849752,63.100995,52.259598",
     "geom:latitude":51.547925,
     "geom:longitude":62.323805,
@@ -117,9 +117,10 @@
         "hasc:id":"KZ.QS.KA",
         "wd:id":"Q703004"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838016,
-    "wof:geomhash":"3dabe248d8be52e3cecae31f0e55af91",
+    "wof:geomhash":"7583e00a5d6a95754c95ef3bc86d3ddf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108785529,
-    "wof:lastmodified":1690938424,
+    "wof:lastmodified":1695886687,
     "wof:name":"Kamystinskiy",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/553/1/1108785531.geojson
+++ b/data/110/878/553/1/1108785531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.704441,
-    "geom:area_square_m":5231038886.522658,
+    "geom:area_square_m":5231038921.518526,
     "geom:bbox":"63.954964,52.595662,65.102389,53.569072",
     "geom:latitude":53.091074,
     "geom:longitude":64.600708,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.QS.AL",
         "wd:id":"Q2476538"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838018,
-    "wof:geomhash":"5efadd59630dc86be8c29926d5f4b421",
+    "wof:geomhash":"59b2655a4b6a0e9022ca2142cd5a2353",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785531,
-    "wof:lastmodified":1690938433,
+    "wof:lastmodified":1695886692,
     "wof:name":"Altynsarinskiy",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/553/3/1108785533.geojson
+++ b/data/110/878/553/3/1108785533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.684822,
-    "geom:area_square_m":12729078905.283186,
+    "geom:area_square_m":12729079737.708166,
     "geom:bbox":"64.688919,51.290282,66.323253,53.187244",
     "geom:latitude":52.336601,
     "geom:longitude":65.405122,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.QS.KS",
         "wd:id":"Q1010136"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838019,
-    "wof:geomhash":"15f2127cc30a33f3bf7f35681a992b7a",
+    "wof:geomhash":"32d07c708bb97682d6cd81eb038c2f80",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785533,
-    "wof:lastmodified":1690938433,
+    "wof:lastmodified":1695886692,
     "wof:name":"Karasuskiy",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/553/5/1108785535.geojson
+++ b/data/110/878/553/5/1108785535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.039394,
-    "geom:area_square_m":7816856165.302346,
+    "geom:area_square_m":7816855942.35164,
     "geom:bbox":"61.989399,51.965329,63.561648,53.043854",
     "geom:latitude":52.53954,
     "geom:longitude":62.793357,
@@ -124,9 +124,10 @@
         "hasc:id":"KZ.QS.TA",
         "wd:id":"Q431619"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838020,
-    "wof:geomhash":"0d2e8bf384c85b883fd72639b202e74e",
+    "wof:geomhash":"95ff2b7f023976516dc09c32b92baf43",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108785535,
-    "wof:lastmodified":1690938434,
+    "wof:lastmodified":1695886692,
     "wof:name":"Taranovskiy",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/553/9/1108785539.geojson
+++ b/data/110/878/553/9/1108785539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.853647,
-    "geom:area_square_m":42032878405.664986,
+    "geom:area_square_m":42032877367.32283,
     "geom:bbox":"52.716362,44.437697,56.743708,46.510801",
     "geom:latitude":45.542623,
     "geom:longitude":54.972286,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.MG.BE",
         "wd:id":"Q650725"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838022,
-    "wof:geomhash":"e042f2bf63e9989c4d72f7b10ba5bd17",
+    "wof:geomhash":"4fa90c91354cfa5d6189df870c90e95d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785539,
-    "wof:lastmodified":1690938433,
+    "wof:lastmodified":1695886692,
     "wof:name":"Beyneuskiy",
     "wof:parent_id":85672923,
     "wof:placetype":"county",

--- a/data/110/878/554/1/1108785541.geojson
+++ b/data/110/878/554/1/1108785541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.374091,
-    "geom:area_square_m":61754259939.490494,
+    "geom:area_square_m":61754260449.228371,
     "geom:bbox":"57.592895,45.382777,62.076063,49.059028",
     "geom:latitude":47.364483,
     "geom:longitude":59.375261,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.AT.SH",
         "wd:id":"Q980931"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838023,
-    "wof:geomhash":"5a97e732ea90e1e55e5b0396dddfb755",
+    "wof:geomhash":"9339d289d9e38d5465ee5308fc8d7915",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785541,
-    "wof:lastmodified":1690938434,
+    "wof:lastmodified":1695886692,
     "wof:name":"Shalkarskiy",
     "wof:parent_id":85672877,
     "wof:placetype":"county",

--- a/data/110/878/554/3/1108785543.geojson
+++ b/data/110/878/554/3/1108785543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.42723,
-    "geom:area_square_m":47913728965.211609,
+    "geom:area_square_m":47913729096.711021,
     "geom:bbox":"51.04987,43.434268,55.998915,45.492668",
     "geom:latitude":44.439209,
     "geom:longitude":53.360655,
@@ -117,9 +117,10 @@
         "hasc:id":"KZ.MG.MA",
         "wd:id":"Q2554467"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838024,
-    "wof:geomhash":"d8edb0f3b6d5d2b22ccb0f91314bdf2d",
+    "wof:geomhash":"fcf792c2ff97be818f37cdcd4fce2d1d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108785543,
-    "wof:lastmodified":1690938434,
+    "wof:lastmodified":1695886692,
     "wof:name":"Manghystauskiy",
     "wof:parent_id":85672923,
     "wof:placetype":"county",

--- a/data/110/878/554/5/1108785545.geojson
+++ b/data/110/878/554/5/1108785545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015268,
-    "geom:area_square_m":132429218.202702,
+    "geom:area_square_m":132429465.465341,
     "geom:bbox":"52.544029,45.37011,52.706638,45.537361",
     "geom:latitude":45.455902,
     "geom:longitude":52.635854,
@@ -59,9 +59,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.MG.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838025,
-    "wof:geomhash":"e50940ff4119be1fdfe5bc7ac1f25a36",
+    "wof:geomhash":"c424c4817afba4c6c4526e04939c4ef1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108785545,
-    "wof:lastmodified":1627522312,
+    "wof:lastmodified":1695886776,
     "wof:name":"Manghystauskiy",
     "wof:parent_id":85672923,
     "wof:placetype":"county",

--- a/data/110/878/554/7/1108785547.geojson
+++ b/data/110/878/554/7/1108785547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000512,
-    "geom:area_square_m":4443160.369856,
+    "geom:area_square_m":4443035.717907,
     "geom:bbox":"52.885649,45.399026,52.960957,45.464314",
     "geom:latitude":45.431622,
     "geom:longitude":52.921344,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.MG.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838026,
-    "wof:geomhash":"b91ef4002cfe01be1a249d66acf2bb12",
+    "wof:geomhash":"1aee088ac231b9444296ddfc69286652",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108785547,
-    "wof:lastmodified":1627522312,
+    "wof:lastmodified":1695886776,
     "wof:name":"Manghystauskiy",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/878/554/9/1108785549.geojson
+++ b/data/110/878/554/9/1108785549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001415,
-    "geom:area_square_m":12629342.876245,
+    "geom:area_square_m":12629249.421008,
     "geom:bbox":"51.10956,43.746549,51.145941,43.815643",
     "geom:latitude":43.784218,
     "geom:longitude":51.127106,
@@ -117,9 +117,10 @@
         "hasc:id":"KZ.MG.AQ",
         "wd:id":"Q720411"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838027,
-    "wof:geomhash":"ab453ea3fb45059d1f59edd72b770029",
+    "wof:geomhash":"6a65df2463f6fe9144291d63e26dfecf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108785549,
-    "wof:lastmodified":1690938434,
+    "wof:lastmodified":1695886692,
     "wof:name":"Aqtau",
     "wof:parent_id":85672923,
     "wof:placetype":"county",

--- a/data/110/878/555/1/1108785551.geojson
+++ b/data/110/878/555/1/1108785551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.061585,
-    "geom:area_square_m":8058862725.573058,
+    "geom:area_square_m":8058863279.817849,
     "geom:bbox":"75.538392,51.495304,77.348165,52.639962",
     "geom:latitude":52.125367,
     "geom:longitude":76.400883,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AA.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838028,
-    "wof:geomhash":"3a90bcf5f795431e71a612a10fbe02b7",
+    "wof:geomhash":"298765fb29b8ce23a9b2379866efd741",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785551,
-    "wof:lastmodified":1627522308,
+    "wof:lastmodified":1695886772,
     "wof:name":"Aksuskiy",
     "wof:parent_id":85672911,
     "wof:placetype":"county",

--- a/data/110/878/555/3/1108785553.geojson
+++ b/data/110/878/555/3/1108785553.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.250362,
-    "geom:area_square_m":9361085547.004971,
+    "geom:area_square_m":9361085270.714241,
     "geom:bbox":"73.684841,52.315819,76.633809,53.143107",
     "geom:latitude":52.737457,
     "geom:longitude":75.229226,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.PA.AT",
         "wd:id":"Q2476575"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838029,
-    "wof:geomhash":"33cf0cd1d9905a49e7b9d7e974fe190d",
+    "wof:geomhash":"74fa4691ad6a001f9dd43c839164ac76",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785553,
-    "wof:lastmodified":1690938424,
+    "wof:lastmodified":1695886686,
     "wof:name":"Aktogayskiy",
     "wof:parent_id":85672911,
     "wof:placetype":"county",

--- a/data/110/878/555/7/1108785557.geojson
+++ b/data/110/878/555/7/1108785557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.929513,
-    "geom:area_square_m":6864732050.178843,
+    "geom:area_square_m":6864731581.277001,
     "geom:bbox":"75.567319,52.831026,77.400406,53.730571",
     "geom:latitude":53.325487,
     "geom:longitude":76.486688,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.PA.KA",
         "wd:id":"Q75251"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838030,
-    "wof:geomhash":"49d0b25d3d8dd7bb453282e8450f8556",
+    "wof:geomhash":"2adb6d6405d2d67b85646b485d8b7159",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785557,
-    "wof:lastmodified":1690938423,
+    "wof:lastmodified":1695886686,
     "wof:name":"Kachirskiy",
     "wof:parent_id":85672911,
     "wof:placetype":"county",

--- a/data/110/878/555/9/1108785559.geojson
+++ b/data/110/878/555/9/1108785559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.03263,
-    "geom:area_square_m":7924805598.62636,
+    "geom:area_square_m":7924805065.014937,
     "geom:bbox":"77.291661,51.140127,79.339548,52.155903",
     "geom:latitude":51.636514,
     "geom:longitude":78.287579,
@@ -129,9 +129,10 @@
         "hasc:id":"KZ.PA.LE",
         "wd:id":"Q47982"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838031,
-    "wof:geomhash":"b3e278e5ec71c515d49fc632fa39444c",
+    "wof:geomhash":"ef2a8ba88ec5c7d4d035bea1b4b3bf89",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108785559,
-    "wof:lastmodified":1690938423,
+    "wof:lastmodified":1695886686,
     "wof:name":"Lebyazhinskiy",
     "wof:parent_id":85672911,
     "wof:placetype":"county",

--- a/data/110/878/556/1/1108785561.geojson
+++ b/data/110/878/556/1/1108785561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.859096,
-    "geom:area_square_m":6481327484.873013,
+    "geom:area_square_m":6481327310.343302,
     "geom:bbox":"76.446404,51.862843,77.934899,52.996401",
     "geom:latitude":52.40069,
     "geom:longitude":77.235503,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.PA.PS",
         "wd:id":"Q509303"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838032,
-    "wof:geomhash":"084853748ebe59ec057962c514bccf5a",
+    "wof:geomhash":"41c5af414898c15f1d8b5148034b8923",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785561,
-    "wof:lastmodified":1690938399,
+    "wof:lastmodified":1695886676,
     "wof:name":"Pavlodarskiy",
     "wof:parent_id":85672911,
     "wof:placetype":"county",

--- a/data/110/878/556/3/1108785563.geojson
+++ b/data/110/878/556/3/1108785563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.682759,
-    "geom:area_square_m":4946915697.197136,
+    "geom:area_square_m":4946915836.544529,
     "geom:bbox":"67.63442,53.727702,69.037402,54.484368",
     "geom:latitude":54.129145,
     "geom:longitude":68.295147,
@@ -59,9 +59,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AM.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838033,
-    "wof:geomhash":"47945791f4698a239960e3a6e16fc77a",
+    "wof:geomhash":"7acc0134202229347bd25b50f046ef89",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108785563,
-    "wof:lastmodified":1627522310,
+    "wof:lastmodified":1695886774,
     "wof:name":"Esil`skiy",
     "wof:parent_id":85672907,
     "wof:placetype":"county",

--- a/data/110/878/556/5/1108785565.geojson
+++ b/data/110/878/556/5/1108785565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.070473,
-    "geom:area_square_m":7695637671.173327,
+    "geom:area_square_m":7695637447.470478,
     "geom:bbox":"66.054569,53.950617,67.950817,54.890167",
     "geom:latitude":54.451307,
     "geom:longitude":66.934571,
@@ -186,9 +186,10 @@
         "hasc:id":"KZ.AA.ZH",
         "wd:id":"Q35902"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838034,
-    "wof:geomhash":"2a9be47d4d51a937c2a39b6e3dfd708e",
+    "wof:geomhash":"78145e396dd255dd6e6a8afe5dad9678",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -198,7 +199,7 @@
         }
     ],
     "wof:id":1108785565,
-    "wof:lastmodified":1690938399,
+    "wof:lastmodified":1695886676,
     "wof:name":"Zhambylskiy",
     "wof:parent_id":85672907,
     "wof:placetype":"county",

--- a/data/110/878/556/7/1108785567.geojson
+++ b/data/110/878/556/7/1108785567.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.640955,
-    "geom:area_square_m":4684298622.805498,
+    "geom:area_square_m":4684299192.455343,
     "geom:bbox":"66.859893,53.2975,67.980404,54.283547",
     "geom:latitude":53.768827,
     "geom:longitude":67.393518,
@@ -111,9 +111,10 @@
         "hasc:id":"KZ.NK.SA",
         "wd:id":"Q32421"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838035,
-    "wof:geomhash":"1af6726b6aa7e7799083983b2d98ef52",
+    "wof:geomhash":"41c07e06a76c04fd12463481d7b68291",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108785567,
-    "wof:lastmodified":1690938398,
+    "wof:lastmodified":1695886776,
     "wof:name":"Shal Akyna",
     "wof:parent_id":85672907,
     "wof:placetype":"county",

--- a/data/110/878/556/9/1108785569.geojson
+++ b/data/110/878/556/9/1108785569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.840087,
-    "geom:area_square_m":6186685468.856657,
+    "geom:area_square_m":6186685652.145633,
     "geom:bbox":"64.802579,53.049347,66.409852,53.966196",
     "geom:latitude":53.446398,
     "geom:longitude":65.680961,
@@ -114,9 +114,10 @@
         "hasc:id":"KZ.QS.SA",
         "wd:id":"Q1249595"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838036,
-    "wof:geomhash":"c019f3f83931955ea04225bec0129cb9",
+    "wof:geomhash":"9be616d8ab5f979b1d3c377b1caf54f7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108785569,
-    "wof:lastmodified":1690938398,
+    "wof:lastmodified":1695886676,
     "wof:name":"Sarykol`skiy",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/557/1/1108785571.geojson
+++ b/data/110/878/557/1/1108785571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.494187,
-    "geom:area_square_m":11179874555.706699,
+    "geom:area_square_m":11179874649.099771,
     "geom:bbox":"66.01023,52.20965,68.056509,53.369349",
     "geom:latitude":52.763043,
     "geom:longitude":66.913651,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.NK.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838037,
-    "wof:geomhash":"dd6c087eace01f5a26aa58728c372648",
+    "wof:geomhash":"9a36b9a49eb7934f795ea4bd4d983611",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785571,
-    "wof:lastmodified":1627522314,
+    "wof:lastmodified":1695886778,
     "wof:name":"Tselinniy",
     "wof:parent_id":85672907,
     "wof:placetype":"county",

--- a/data/110/878/557/5/1108785575.geojson
+++ b/data/110/878/557/5/1108785575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.377835,
-    "geom:area_square_m":10295892677.497793,
+    "geom:area_square_m":10295892794.219391,
     "geom:bbox":"70.418175,52.314449,72.863113,53.409466",
     "geom:latitude":52.819838,
     "geom:longitude":71.529256,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AM.EN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838043,
-    "wof:geomhash":"ae1e0de395fbbea813de2f1e312a7109",
+    "wof:geomhash":"85cb9277f5f391e2ac3dc0ff79b561c0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785575,
-    "wof:lastmodified":1627522310,
+    "wof:lastmodified":1695886774,
     "wof:name":"Enbekshil`derskiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/557/7/1108785577.geojson
+++ b/data/110/878/557/7/1108785577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.607069,
-    "geom:area_square_m":11730226122.28507,
+    "geom:area_square_m":11730226158.536486,
     "geom:bbox":"68.585874,53.224792,71.144496,54.404809",
     "geom:latitude":53.821542,
     "geom:longitude":69.981875,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.NK.TA",
         "wd:id":"Q35899"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838044,
-    "wof:geomhash":"8a633a6d7fe9f9fdd78c2f608978b515",
+    "wof:geomhash":"2cfc42f1459e3839743d660f0db2e7df",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785577,
-    "wof:lastmodified":1690938410,
+    "wof:lastmodified":1695886777,
     "wof:name":"Taiynshinskiy",
     "wof:parent_id":85672907,
     "wof:placetype":"county",

--- a/data/110/878/557/9/1108785579.geojson
+++ b/data/110/878/557/9/1108785579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.275976,
-    "geom:area_square_m":9455353015.370703,
+    "geom:area_square_m":9455352413.441614,
     "geom:bbox":"67.232592,52.538506,68.787028,53.832844",
     "geom:latitude":53.180536,
     "geom:longitude":68.087476,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.NK.AY",
         "wd:id":"Q2029854"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838045,
-    "wof:geomhash":"bb5e909bbcf27cf17337a3997fb7c77f",
+    "wof:geomhash":"26c5c9f061eb481ebe5fd5fc994074f1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785579,
-    "wof:lastmodified":1690938409,
+    "wof:lastmodified":1695886772,
     "wof:name":"Ayyrtauskiy",
     "wof:parent_id":85672907,
     "wof:placetype":"county",

--- a/data/110/878/558/1/1108785581.geojson
+++ b/data/110/878/558/1/1108785581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.701797,
-    "geom:area_square_m":6425084793.073676,
+    "geom:area_square_m":6425083973.754543,
     "geom:bbox":"66.790294,41.936424,69.214507,42.751681",
     "geom:latitude":42.234277,
     "geom:longitude":68.197977,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.SK.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838046,
-    "wof:geomhash":"0358ca901bf1d25ad3e228ec917d645d",
+    "wof:geomhash":"76e5d0a5d74262eb2de32b39f2b4901b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785581,
-    "wof:lastmodified":1627522309,
+    "wof:lastmodified":1695886773,
     "wof:name":"Arysskiy",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/558/3/1108785583.geojson
+++ b/data/110/878/558/3/1108785583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.794309,
-    "geom:area_square_m":7177371563.246522,
+    "geom:area_square_m":7177372133.004686,
     "geom:bbox":"68.780456,42.599283,70.245276,43.576818",
     "geom:latitude":43.049388,
     "geom:longitude":69.484308,
@@ -117,9 +117,10 @@
         "hasc:id":"KZ.SK.BA",
         "wd:id":"Q522660"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838048,
-    "wof:geomhash":"b14b31f14d8b6c8bc619b81e4a3905c0",
+    "wof:geomhash":"cbcf62dc96be9b1707ee80cc451181b7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108785583,
-    "wof:lastmodified":1690938402,
+    "wof:lastmodified":1695886773,
     "wof:name":"Baydibekskiy",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/558/5/1108785585.geojson
+++ b/data/110/878/558/5/1108785585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.430928,
-    "geom:area_square_m":3964935233.916653,
+    "geom:area_square_m":3964935325.169005,
     "geom:bbox":"68.857911,41.555242,70.341681,42.219432",
     "geom:latitude":41.918051,
     "geom:longitude":69.599491,
@@ -129,9 +129,10 @@
         "hasc:id":"KZ.SK.KA",
         "wd:id":"Q1370228"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838049,
-    "wof:geomhash":"3272d58e544c22b994da3feef528791b",
+    "wof:geomhash":"5862fdac53b1d55054ff862fd5f0fb53",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108785585,
-    "wof:lastmodified":1690938403,
+    "wof:lastmodified":1695886775,
     "wof:name":"Kazygurtskiy",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/558/7/1108785587.geojson
+++ b/data/110/878/558/7/1108785587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070124,
-    "geom:area_square_m":635617938.59818,
+    "geom:area_square_m":635617684.122495,
     "geom:bbox":"68.794991,42.691223,69.172415,43.047126",
     "geom:latitude":42.858192,
     "geom:longitude":68.952063,
@@ -59,9 +59,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.SK.OR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838050,
-    "wof:geomhash":"22599ffb6f5d15f782b5206ac8fb6b4c",
+    "wof:geomhash":"b15af70c616cad20cbecb3c42aa6b03f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108785587,
-    "wof:lastmodified":1627522312,
+    "wof:lastmodified":1695886776,
     "wof:name":"Ordabasynskiy",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/558/9/1108785589.geojson
+++ b/data/110/878/558/9/1108785589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.230911,
-    "geom:area_square_m":2105670676.741233,
+    "geom:area_square_m":2105670907.030459,
     "geom:bbox":"68.827354,42.19539,69.607634,42.781343",
     "geom:latitude":42.483442,
     "geom:longitude":69.221141,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.SK.OR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838051,
-    "wof:geomhash":"73c0928650ac81cd202ab978e4efea47",
+    "wof:geomhash":"69c3c5b648fa533aa614386c3afd9125",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785589,
-    "wof:lastmodified":1627522312,
+    "wof:lastmodified":1695886776,
     "wof:name":"Ordabasynskiy",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/559/3/1108785593.geojson
+++ b/data/110/878/559/3/1108785593.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.841284,
-    "geom:area_square_m":16773694758.178673,
+    "geom:area_square_m":16773694972.345196,
     "geom:bbox":"65.998692,41.869615,68.953637,43.174908",
     "geom:latitude":42.545775,
     "geom:longitude":67.433489,
@@ -114,9 +114,10 @@
         "hasc:id":"KZ.SK.OT",
         "wd:id":"Q2554487"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838052,
-    "wof:geomhash":"12b235fabb591f24cfb92eab10858e7f",
+    "wof:geomhash":"8e529284cad2bf6cc34ed7c3b4c59ef0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108785593,
-    "wof:lastmodified":1690938407,
+    "wof:lastmodified":1695886777,
     "wof:name":"Otrarskiy",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/559/5/1108785595.geojson
+++ b/data/110/878/559/5/1108785595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.130091,
-    "geom:area_square_m":1186966346.975854,
+    "geom:area_square_m":1186965715.448819,
     "geom:bbox":"69.434464,42.260895,70.082886,42.639961",
     "geom:latitude":42.448306,
     "geom:longitude":69.761257,
@@ -111,9 +111,10 @@
         "hasc:id":"KZ.SK.SR",
         "wd:id":"Q574486"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838053,
-    "wof:geomhash":"a3244c5de61bc8f00fcca056b9e952ae",
+    "wof:geomhash":"4585c7c7cf3cb8bb85f8cb39028c533f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108785595,
-    "wof:lastmodified":1690938407,
+    "wof:lastmodified":1695886777,
     "wof:name":"Sayramskiy",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/559/7/1108785597.geojson
+++ b/data/110/878/559/7/1108785597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.607748,
-    "geom:area_square_m":63504924264.740227,
+    "geom:area_square_m":63504923468.718323,
     "geom:bbox":"68.528533,45.998255,72.130377,49.381879",
     "geom:latitude":47.533877,
     "geom:longitude":70.405015,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.QG.ZA",
         "wd:id":"Q2726480"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838059,
-    "wof:geomhash":"14fc78dea2cf9f5d3de94966fda74578",
+    "wof:geomhash":"697f275c4208e7aa3485067c52b4c569",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785597,
-    "wof:lastmodified":1690938407,
+    "wof:lastmodified":1695886679,
     "wof:name":"Zhanaarkinskiy",
     "wof:parent_id":85672905,
     "wof:placetype":"county",

--- a/data/110/878/559/9/1108785599.geojson
+++ b/data/110/878/559/9/1108785599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.65107,
-    "geom:area_square_m":40757187372.27459,
+    "geom:area_square_m":40757187617.672058,
     "geom:bbox":"67.181242,43.408402,69.822445,46.001822",
     "geom:latitude":44.868663,
     "geom:longitude":68.569573,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.SK.SU",
         "wd:id":"Q2554556"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838060,
-    "wof:geomhash":"ce649fc4e0879c2c92bd41aef257bacb",
+    "wof:geomhash":"37b89eadea32f7741d078ebb476d4c9c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785599,
-    "wof:lastmodified":1690938406,
+    "wof:lastmodified":1695886679,
     "wof:name":"Suzakskiy",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/560/1/1108785601.geojson
+++ b/data/110/878/560/1/1108785601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005153,
-    "geom:area_square_m":47180500.712639,
+    "geom:area_square_m":47180466.977031,
     "geom:bbox":"69.388535,42.173689,69.516144,42.257363",
     "geom:latitude":42.226266,
     "geom:longitude":69.460879,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.SK.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838061,
-    "wof:geomhash":"a47d1ff3a5f2d84a496028da6bf992ae",
+    "wof:geomhash":"a722ab1850c90770a31afef723b36194",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785601,
-    "wof:lastmodified":1627522313,
+    "wof:lastmodified":1695886777,
     "wof:name":"Sayramskiy",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/560/3/1108785603.geojson
+++ b/data/110/878/560/3/1108785603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.342178,
-    "geom:area_square_m":3092454860.427892,
+    "geom:area_square_m":3092454531.757701,
     "geom:bbox":"70.703867,42.693796,71.874107,43.433485",
     "geom:latitude":43.038931,
     "geom:longitude":71.150348,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AA.ZH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838062,
-    "wof:geomhash":"2973569af11d0a121f03f4b456f99117",
+    "wof:geomhash":"06ced3fa2df5f8120e85b73ae5c719ee",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785603,
-    "wof:lastmodified":1627522313,
+    "wof:lastmodified":1695886777,
     "wof:name":"Zhambylskiy",
     "wof:parent_id":85672931,
     "wof:placetype":"county",

--- a/data/110/878/560/5/1108785605.geojson
+++ b/data/110/878/560/5/1108785605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.252252,
-    "geom:area_square_m":2297942292.411672,
+    "geom:area_square_m":2297942311.63935,
     "geom:bbox":"69.76977,42.330646,70.803103,42.824832",
     "geom:latitude":42.546961,
     "geom:longitude":70.246559,
@@ -129,9 +129,10 @@
         "hasc:id":"KZ.SK.TY",
         "wd:id":"Q2554511"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838063,
-    "wof:geomhash":"6b4491fb2d72f6784cf6f07a627f878e",
+    "wof:geomhash":"16b3956d0c5236eeb654ee4561af965a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108785605,
-    "wof:lastmodified":1690938400,
+    "wof:lastmodified":1695886778,
     "wof:name":"Tyul`kubaskiy",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/560/7/1108785607.geojson
+++ b/data/110/878/560/7/1108785607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085769,
-    "geom:area_square_m":784610998.152129,
+    "geom:area_square_m":784610998.152239,
     "geom:bbox":"69.2268365191,42.1137472398,69.7450727546,42.4513473573",
     "geom:latitude":42.284512,
     "geom:longitude":69.527794,
@@ -251,9 +251,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.SK.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838065,
-    "wof:geomhash":"0874104694f77a39fc19e72c474f75a0",
+    "wof:geomhash":"8e109b6df5cd74c9b4b68f2cc3116d8d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -263,7 +264,7 @@
         }
     ],
     "wof:id":1108785607,
-    "wof:lastmodified":1566591742,
+    "wof:lastmodified":1695886677,
     "wof:name":"Shymkent",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/561/1/1108785611.geojson
+++ b/data/110/878/561/1/1108785611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.531762,
-    "geom:area_square_m":4176001823.173947,
+    "geom:area_square_m":4176001821.470931,
     "geom:bbox":"81.632016,50.178322,83.045187,50.927274",
     "geom:latitude":50.572343,
     "geom:longitude":82.244429,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.EK.SH",
         "wd:id":"Q2466428"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838066,
-    "wof:geomhash":"c60f542b5da07169f95e61b28d5b0f72",
+    "wof:geomhash":"f4465773228a11c742e23eef1ad832d6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785611,
-    "wof:lastmodified":1690938408,
+    "wof:lastmodified":1695886679,
     "wof:name":"Shemonaikhinskiy",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/561/3/1108785613.geojson
+++ b/data/110/878/561/3/1108785613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.53258,
-    "geom:area_square_m":39448500060.930893,
+    "geom:area_square_m":39448502203.155243,
     "geom:bbox":"60.173435,43.576581,63.351155,47.102849",
     "geom:latitude":45.256695,
     "geom:longitude":62.141119,
@@ -114,9 +114,10 @@
         "hasc:id":"KZ.QO.KZ",
         "wd:id":"Q976752"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838067,
-    "wof:geomhash":"17454aadf349e10374f63dbef035f394",
+    "wof:geomhash":"20bb54139cfc9ed03ba41fad13386236",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108785613,
-    "wof:lastmodified":1690938409,
+    "wof:lastmodified":1695886680,
     "wof:name":"Kazalinskiy",
     "wof:parent_id":85672885,
     "wof:placetype":"county",

--- a/data/110/878/561/5/1108785615.geojson
+++ b/data/110/878/561/5/1108785615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.897076,
-    "geom:area_square_m":6780616910.776166,
+    "geom:area_square_m":6780617252.230194,
     "geom:bbox":"77.630292,51.775368,79.129567,52.885694",
     "geom:latitude":52.317497,
     "geom:longitude":78.328444,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.PA.SH",
         "wd:id":"Q2554498"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838068,
-    "wof:geomhash":"f875888bd8247925c8ff163d443f6aa4",
+    "wof:geomhash":"fc4e02df9ba5782e270f514e7ff8d62e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785615,
-    "wof:lastmodified":1690938409,
+    "wof:lastmodified":1695886680,
     "wof:name":"Sherbaktinskiy",
     "wof:parent_id":85672911,
     "wof:placetype":"county",

--- a/data/110/878/561/7/1108785617.geojson
+++ b/data/110/878/561/7/1108785617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.427979,
-    "geom:area_square_m":10834131307.625051,
+    "geom:area_square_m":10834131325.545712,
     "geom:bbox":"70.151741,51.751968,72.722088,52.675869",
     "geom:latitude":52.150886,
     "geom:longitude":71.531528,
@@ -129,9 +129,10 @@
         "hasc:id":"KZ.AM.AK",
         "wd:id":"Q2456359"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838069,
-    "wof:geomhash":"269cb8974ca165fdf38b63a3267513dd",
+    "wof:geomhash":"d0647de43347e49d5eaad2f4eb06051f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108785617,
-    "wof:lastmodified":1690938408,
+    "wof:lastmodified":1695886679,
     "wof:name":"Akkol`skiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/561/9/1108785619.geojson
+++ b/data/110/878/561/9/1108785619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.331081,
-    "geom:area_square_m":17803256435.841225,
+    "geom:area_square_m":17803256138.875584,
     "geom:bbox":"71.958727,50.942788,74.253596,52.748042",
     "geom:latitude":51.854137,
     "geom:longitude":73.130675,
@@ -127,9 +127,10 @@
         "hasc:id":"KZ.AM.ER",
         "wd:id":"Q2565654"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838070,
-    "wof:geomhash":"c139f8a9a4dfc4497005e2baaf54dd74",
+    "wof:geomhash":"d0752cfdd50306bc77a94b87c8e7d65b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108785619,
-    "wof:lastmodified":1690938407,
+    "wof:lastmodified":1695886680,
     "wof:name":"Ereymengauskiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/562/1/1108785621.geojson
+++ b/data/110/878/562/1/1108785621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.063584,
-    "geom:area_square_m":8119137592.083112,
+    "geom:area_square_m":8119137437.613497,
     "geom:bbox":"65.40941,51.328434,67.116654,52.448946",
     "geom:latitude":51.876079,
     "geom:longitude":66.298553,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AM.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838072,
-    "wof:geomhash":"b3cabd4b453faea56750a787842721c3",
+    "wof:geomhash":"6b6bc7117f2eef2a5bb4c87124f5b002",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785621,
-    "wof:lastmodified":1627522310,
+    "wof:lastmodified":1695886774,
     "wof:name":"Esil`skiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/562/3/1108785623.geojson
+++ b/data/110/878/562/3/1108785623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.306585,
-    "geom:area_square_m":10025555737.342972,
+    "geom:area_square_m":10025556083.618607,
     "geom:bbox":"66.81122,50.903962,68.12939,52.435161",
     "geom:latitude":51.643419,
     "geom:longitude":67.491402,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.AM.ZS",
         "wd:id":"Q2605063"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838073,
-    "wof:geomhash":"84a814249d70342d54aef5149caac511",
+    "wof:geomhash":"c55a67ca06d1f91d64101ffa78e27a13",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785623,
-    "wof:lastmodified":1690938431,
+    "wof:lastmodified":1695886690,
     "wof:name":"Zhaksynskiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/562/5/1108785625.geojson
+++ b/data/110/878/562/5/1108785625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.77975,
-    "geom:area_square_m":6064335340.632706,
+    "geom:area_square_m":6064335491.921755,
     "geom:bbox":"70.374621,50.472301,71.789495,51.518818",
     "geom:latitude":51.025711,
     "geom:longitude":70.987635,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.AM.TS",
         "wd:id":"Q2224859"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838074,
-    "wof:geomhash":"37275927dd416e85d70c1cdfa1d20bde",
+    "wof:geomhash":"ac452ef7dfb0e2b8188306eb499eb8de",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785625,
-    "wof:lastmodified":1690938431,
+    "wof:lastmodified":1695886691,
     "wof:name":"Tselinogradskiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/562/9/1108785629.geojson
+++ b/data/110/878/562/9/1108785629.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.767814,
-    "geom:area_square_m":5725507468.141331,
+    "geom:area_square_m":5725507349.734462,
     "geom:bbox":"69.312136,52.410783,70.872314,53.409899",
     "geom:latitude":52.910581,
     "geom:longitude":70.108921,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AM.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838075,
-    "wof:geomhash":"d5b1dd34d2c32901df9aa43f424948b8",
+    "wof:geomhash":"e1695e1ddd47431ca9baef9bf7cf238c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785629,
-    "wof:lastmodified":1627522310,
+    "wof:lastmodified":1695886774,
     "wof:name":"Shuchinskiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/563/1/1108785631.geojson
+++ b/data/110/878/563/1/1108785631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.298545,
-    "geom:area_square_m":2356100688.187156,
+    "geom:area_square_m":2356100374.773143,
     "geom:bbox":"56.867024,50.113799,57.788218,50.59531",
     "geom:latitude":50.339261,
     "geom:longitude":57.320103,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.AT.AQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838077,
-    "wof:geomhash":"c8411f9f4606e138a8fd3732231d8e55",
+    "wof:geomhash":"5cf6bf59e54d681012ba85ef17ebbf03",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785631,
-    "wof:lastmodified":1627522309,
+    "wof:lastmodified":1695886773,
     "wof:name":"Aqtobe",
     "wof:parent_id":85672877,
     "wof:placetype":"county",

--- a/data/110/878/563/3/1108785633.geojson
+++ b/data/110/878/563/3/1108785633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.183871,
-    "geom:area_square_m":52849885135.767822,
+    "geom:area_square_m":52849885221.976494,
     "geom:bbox":"58.929517,44.815327,62.940294,47.841251",
     "geom:latitude":46.273157,
     "geom:longitude":60.876327,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.QO.AR",
         "wd:id":"Q2726397"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838078,
-    "wof:geomhash":"4a0a9fe974a3534c3557fa88f74830d8",
+    "wof:geomhash":"1e89051b28137f9c1150ac64c632a5e5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785633,
-    "wof:lastmodified":1690938427,
+    "wof:lastmodified":1695886689,
     "wof:name":"Aral`skiy",
     "wof:parent_id":85672885,
     "wof:placetype":"county",

--- a/data/110/878/563/5/1108785635.geojson
+++ b/data/110/878/563/5/1108785635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.51478,
-    "geom:area_square_m":4503881080.464879,
+    "geom:area_square_m":4503881401.101322,
     "geom:bbox":"78.060996,44.624764,79.94749,45.400943",
     "geom:latitude":44.962965,
     "geom:longitude":78.816353,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.AA.TQ",
         "wd:id":"Q2550435"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838079,
-    "wof:geomhash":"cf6be1b4e019756bc81eb47869624bca",
+    "wof:geomhash":"547a971a31a41b550f1311b549050148",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785635,
-    "wof:lastmodified":1690938427,
+    "wof:lastmodified":1695886661,
     "wof:name":"Taldyqorghan",
     "wof:parent_id":85672921,
     "wof:placetype":"county",

--- a/data/110/878/563/7/1108785637.geojson
+++ b/data/110/878/563/7/1108785637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.409154,
-    "geom:area_square_m":28850536056.79612,
+    "geom:area_square_m":28850536015.020264,
     "geom:bbox":"52.732971,45.993159,56.474642,47.781296",
     "geom:latitude":46.810538,
     "geom:longitude":54.245296,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.AR.ZH",
         "wd:id":"Q2550349"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838080,
-    "wof:geomhash":"66b9d3925efa75ed651fe959c8ea5229",
+    "wof:geomhash":"0158ef8f80a6d6547fb822f027a31cd6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785637,
-    "wof:lastmodified":1690938426,
+    "wof:lastmodified":1695886688,
     "wof:name":"Zhylyoyskiy",
     "wof:parent_id":85672889,
     "wof:placetype":"county",

--- a/data/110/878/563/9/1108785639.geojson
+++ b/data/110/878/563/9/1108785639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.302249,
-    "geom:area_square_m":10132532592.308315,
+    "geom:area_square_m":10132532447.68519,
     "geom:bbox":"78.089118,50.412187,79.941647,51.718525",
     "geom:latitude":51.004667,
     "geom:longitude":79.101149,
@@ -132,9 +132,10 @@
         "hasc:id":"KZ.EK.BE",
         "wd:id":"Q2466416"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838081,
-    "wof:geomhash":"6b036395e41f5fec6e9fb5ab0a401eb9",
+    "wof:geomhash":"264940dcbd7b287a365b6ca5f7a5a1ae",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108785639,
-    "wof:lastmodified":1690938426,
+    "wof:lastmodified":1695886688,
     "wof:name":"Beskaragayskiy",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/564/1/1108785641.geojson
+++ b/data/110/878/564/1/1108785641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.653572,
-    "geom:area_square_m":29133084784.65625,
+    "geom:area_square_m":29133084784.6562,
     "geom:bbox":"77.0510755733,48.6297434601,81.3901916372,50.9193360668",
     "geom:latitude":49.842592,
     "geom:longitude":78.891138,
@@ -223,7 +223,7 @@
     "wof:concordances":{},
     "wof:country":"KZ",
     "wof:created":1481838082,
-    "wof:geomhash":"271154584404366bddd0cd78a15a9eb4",
+    "wof:geomhash":"e242250d8569d6f07b841e32fa6ba5b2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -233,7 +233,7 @@
         }
     ],
     "wof:id":1108785641,
-    "wof:lastmodified":1566591778,
+    "wof:lastmodified":1695886687,
     "wof:name":"Semey",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/564/3/1108785643.geojson
+++ b/data/110/878/564/3/1108785643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.358568,
-    "geom:area_square_m":12134515749.293203,
+    "geom:area_square_m":12134516076.360584,
     "geom:bbox":"69.913555,42.918563,71.630499,44.483577",
     "geom:latitude":43.750869,
     "geom:longitude":70.83524,
@@ -135,9 +135,10 @@
         "hasc:id":"KZ.ZM.TL",
         "wd:id":"Q2422636"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838083,
-    "wof:geomhash":"ee0a87cfaedcbb7650128e3b36215f48",
+    "wof:geomhash":"9fca950954a2131fd64f86ef5955f15a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108785643,
-    "wof:lastmodified":1690938426,
+    "wof:lastmodified":1695886688,
     "wof:name":"Talasskiy",
     "wof:parent_id":85672931,
     "wof:placetype":"county",

--- a/data/110/878/564/7/1108785647.geojson
+++ b/data/110/878/564/7/1108785647.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.546342,
-    "geom:area_square_m":20707649141.295498,
+    "geom:area_square_m":20707649157.474991,
     "geom:bbox":"48.951524,47.95181,51.322173,49.854616",
     "geom:latitude":48.875538,
     "geom:longitude":50.117686,
@@ -118,9 +118,10 @@
         "hasc:id":"KZ.WK.DG",
         "wd:id":"Q2736638"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838084,
-    "wof:geomhash":"81d31e1862ca5e7ad992ba3d4fcb792b",
+    "wof:geomhash":"df1757f76793a769e85906fbd5228e4c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108785647,
-    "wof:lastmodified":1690938425,
+    "wof:lastmodified":1695886688,
     "wof:name":"Dzhangalinskiy",
     "wof:parent_id":85672893,
     "wof:placetype":"county",

--- a/data/110/878/564/9/1108785649.geojson
+++ b/data/110/878/564/9/1108785649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.828735,
-    "geom:area_square_m":6659121461.129363,
+    "geom:area_square_m":6659122107.448958,
     "geom:bbox":"71.579586,49.150089,73.831601,49.82334",
     "geom:latitude":49.471041,
     "geom:longitude":72.515038,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.EK.AB",
         "wd:id":"Q2283566"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838085,
-    "wof:geomhash":"83c767e4d569c2154257c9cd47f0ecd4",
+    "wof:geomhash":"66ea6a7c3d04857c10dd9f9842302fd2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785649,
-    "wof:lastmodified":1690938425,
+    "wof:lastmodified":1695886688,
     "wof:name":"Abayskiy",
     "wof:parent_id":85672905,
     "wof:placetype":"county",

--- a/data/110/878/565/1/1108785651.geojson
+++ b/data/110/878/565/1/1108785651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.971132,
-    "geom:area_square_m":15653896299.787039,
+    "geom:area_square_m":15653896388.513775,
     "geom:bbox":"71.970192,49.400223,75.132689,50.65808",
     "geom:latitude":50.039526,
     "geom:longitude":73.689365,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.QG.BZ",
         "wd:id":"Q2726463"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838086,
-    "wof:geomhash":"fd8271d872c4b75e64e4a44de9e55508",
+    "wof:geomhash":"654cac05898670d59d2863b998775bb5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785651,
-    "wof:lastmodified":1690938432,
+    "wof:lastmodified":1695886691,
     "wof:name":"Bukhar-Zhyrauskiy",
     "wof:parent_id":85672905,
     "wof:placetype":"county",

--- a/data/110/878/565/3/1108785653.geojson
+++ b/data/110/878/565/3/1108785653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.453231,
-    "geom:area_square_m":11408023155.170073,
+    "geom:area_square_m":11408024046.129883,
     "geom:bbox":"71.640416,49.929963,74.051012,51.311965",
     "geom:latitude":50.590038,
     "geom:longitude":73.008061,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.QG.OS",
         "wd:id":"Q737748"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838088,
-    "wof:geomhash":"f0e696eb4f0a3b801badddcdaaa9bef1",
+    "wof:geomhash":"fbd59d618aae330505511195b02b557c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785653,
-    "wof:lastmodified":1690938432,
+    "wof:lastmodified":1695886691,
     "wof:name":"Osakarovskiy",
     "wof:parent_id":85672905,
     "wof:placetype":"county",

--- a/data/110/878/565/5/1108785655.geojson
+++ b/data/110/878/565/5/1108785655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.344568,
-    "geom:area_square_m":18321863172.792091,
+    "geom:area_square_m":18321862937.670303,
     "geom:bbox":"73.882962,50.008038,76.778845,51.646551",
     "geom:latitude":50.802571,
     "geom:longitude":75.494584,
@@ -132,9 +132,10 @@
         "hasc:id":"KZ.PA.BA",
         "wd:id":"Q2448467"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838089,
-    "wof:geomhash":"3d3b596b5fad2880ed7096fadf252976",
+    "wof:geomhash":"ef1186c0d52ff747f54487b84f0f495d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108785655,
-    "wof:lastmodified":1690938432,
+    "wof:lastmodified":1695886691,
     "wof:name":"Bayanaul`skiy",
     "wof:parent_id":85672911,
     "wof:placetype":"county",

--- a/data/110/878/565/7/1108785657.geojson
+++ b/data/110/878/565/7/1108785657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.435317,
-    "geom:area_square_m":27334458147.372326,
+    "geom:area_square_m":27334458739.249023,
     "geom:bbox":"64.27705,48.674276,66.846211,51.207524",
     "geom:latitude":49.944287,
     "geom:longitude":65.454358,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.QS.AM",
         "wd:id":"Q2476619"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838090,
-    "wof:geomhash":"aed0fea13e37a9e68e1be498f1421a7b",
+    "wof:geomhash":"eb3d5f932759a1a9dba2769b2aeb8ca1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785657,
-    "wof:lastmodified":1690938432,
+    "wof:lastmodified":1695886691,
     "wof:name":"Amangel`dinskiy",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/565/9/1108785659.geojson
+++ b/data/110/878/565/9/1108785659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.436299,
-    "geom:area_square_m":10878044960.378963,
+    "geom:area_square_m":10878045303.668488,
     "geom:bbox":"62.800347,51.692206,65.014132,52.86304",
     "geom:latitude":52.229054,
     "geom:longitude":63.93437,
@@ -114,9 +114,10 @@
         "hasc:id":"KZ.QS.AU",
         "wd:id":"Q1427082"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838091,
-    "wof:geomhash":"76903a16c8b1a59503322fb31ec15ce8",
+    "wof:geomhash":"cab9433ea96d517e367b5236e88c1245",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108785659,
-    "wof:lastmodified":1690938431,
+    "wof:lastmodified":1695886691,
     "wof:name":"Auliekol`skiy",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/566/1/1108785661.geojson
+++ b/data/110/878/566/1/1108785661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.898402,
-    "geom:area_square_m":6746110060.434252,
+    "geom:area_square_m":6746110363.980032,
     "geom:bbox":"60.712023,52.143406,62.554985,53.036277",
     "geom:latitude":52.607334,
     "geom:longitude":61.629555,
@@ -114,9 +114,10 @@
         "hasc:id":"KZ.QS.DE",
         "wd:id":"Q1510481"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838092,
-    "wof:geomhash":"7e780ff702b43e75bcc8e5865ff1f41c",
+    "wof:geomhash":"97f039f62c015e4984b0cd9ec58fd30e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108785661,
-    "wof:lastmodified":1690938406,
+    "wof:lastmodified":1695886679,
     "wof:name":"Denisovskiy",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/566/5/1108785665.geojson
+++ b/data/110/878/566/5/1108785665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.094957,
-    "geom:area_square_m":8104310134.967321,
+    "geom:area_square_m":8104309065.286894,
     "geom:bbox":"62.574064,52.654918,64.473962,53.82779",
     "geom:latitude":53.231684,
     "geom:longitude":63.545568,
@@ -129,9 +129,10 @@
         "hasc:id":"KZ.QS.QO",
         "wd:id":"Q619361"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838093,
-    "wof:geomhash":"759321ea5d4c46fb932cbf63810cc7a3",
+    "wof:geomhash":"c221cb3695a1526c77b18c5c680220e3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108785665,
-    "wof:lastmodified":1690938406,
+    "wof:lastmodified":1695886679,
     "wof:name":"Qostanay",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/566/7/1108785667.geojson
+++ b/data/110/878/566/7/1108785667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.893326,
-    "geom:area_square_m":8018931332.610861,
+    "geom:area_square_m":8018931332.610273,
     "geom:bbox":"67.6603778637,42.9722546676,69.058337096,44.020065875",
     "geom:latitude":43.451718,
     "geom:longitude":68.347366,
@@ -233,9 +233,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.SK.TU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838094,
-    "wof:geomhash":"2588089c586a4df2922f1f49b6c9e8d9",
+    "wof:geomhash":"6552a163858a9198ae1ee5d9b0adeb31",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -245,7 +246,7 @@
         }
     ],
     "wof:id":1108785667,
-    "wof:lastmodified":1566591752,
+    "wof:lastmodified":1695886679,
     "wof:name":"Turkestan",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/566/9/1108785669.geojson
+++ b/data/110/878/566/9/1108785669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.815654,
-    "geom:area_square_m":16288735460.339792,
+    "geom:area_square_m":16288736099.036678,
     "geom:bbox":"66.087714,42.333889,68.06251,44.444044",
     "geom:latitude":43.485138,
     "geom:longitude":67.134831,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.QO.ZN",
         "wd:id":"Q2726410"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838095,
-    "wof:geomhash":"ca15456ab059e98c9f2565d74cc8d0fb",
+    "wof:geomhash":"ea4c9c5c2c84a469d435445caf79bdfd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785669,
-    "wof:lastmodified":1690938405,
+    "wof:lastmodified":1695886678,
     "wof:name":"Zhanakorganskiy",
     "wof:parent_id":85672885,
     "wof:placetype":"county",

--- a/data/110/878/567/1/1108785671.geojson
+++ b/data/110/878/567/1/1108785671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.295355,
-    "geom:area_square_m":28648058584.343807,
+    "geom:area_square_m":28648058005.318348,
     "geom:bbox":"64.652142,43.667786,67.36139,46.503097",
     "geom:latitude":45.322992,
     "geom:longitude":65.639442,
@@ -113,7 +113,7 @@
     },
     "wof:country":"KZ",
     "wof:created":1481838096,
-    "wof:geomhash":"7f44608f28818091b978da9a888f0f40",
+    "wof:geomhash":"0d754cd62b34509310ae51956435e40a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +123,7 @@
         }
     ],
     "wof:id":1108785671,
-    "wof:lastmodified":1690938401,
+    "wof:lastmodified":1695886677,
     "wof:name":"Syrdariya",
     "wof:parent_id":85672885,
     "wof:placetype":"county",

--- a/data/110/878/567/3/1108785673.geojson
+++ b/data/110/878/567/3/1108785673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.64132,
-    "geom:area_square_m":23134286662.019482,
+    "geom:area_square_m":23134287632.535778,
     "geom:bbox":"63.400057,43.572047,64.942654,46.841176",
     "geom:latitude":44.893168,
     "geom:longitude":64.278561,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.QO.ZL",
         "wd:id":"Q2726452"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838097,
-    "wof:geomhash":"11637f0920f76f5096c01e39ed0f0782",
+    "wof:geomhash":"79edc1b9f1a4ae419477e0be06ef169c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785673,
-    "wof:lastmodified":1690938401,
+    "wof:lastmodified":1695886677,
     "wof:name":"Zhalagashskiy",
     "wof:parent_id":85672885,
     "wof:placetype":"county",

--- a/data/110/878/567/5/1108785675.geojson
+++ b/data/110/878/567/5/1108785675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.562487,
-    "geom:area_square_m":31555704528.300735,
+    "geom:area_square_m":31555704382.761795,
     "geom:bbox":"64.956023,42.633201,67.52907,45.709578",
     "geom:latitude":44.241581,
     "geom:longitude":66.377699,
@@ -137,7 +137,7 @@
     },
     "wof:country":"KZ",
     "wof:created":1481838098,
-    "wof:geomhash":"2423508dcb62b380b6bbfcbbf8cf3a7d",
+    "wof:geomhash":"b9ec72fe42d218b46450eb1cfbc72d01",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -147,7 +147,7 @@
         }
     ],
     "wof:id":1108785675,
-    "wof:lastmodified":1690938402,
+    "wof:lastmodified":1695886660,
     "wof:name":"Shieli",
     "wof:parent_id":85672885,
     "wof:placetype":"county",

--- a/data/110/878/567/7/1108785677.geojson
+++ b/data/110/878/567/7/1108785677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.265049,
-    "geom:area_square_m":2318949329.479113,
+    "geom:area_square_m":2318949617.415321,
     "geom:bbox":"65.135346,44.622973,65.902401,45.377301",
     "geom:latitude":44.962712,
     "geom:longitude":65.488941,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.QO.QY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838099,
-    "wof:geomhash":"253068a8ddb89474ea1624695d348976",
+    "wof:geomhash":"1c9abac895eb150ed54ce86798e47f91",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108785677,
-    "wof:lastmodified":1636495696,
+    "wof:lastmodified":1695886660,
     "wof:name":"Qyzylorda",
     "wof:parent_id":85672885,
     "wof:placetype":"county",

--- a/data/110/878/567/9/1108785679.geojson
+++ b/data/110/878/567/9/1108785679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.386542,
-    "geom:area_square_m":10249859334.634651,
+    "geom:area_square_m":10249859295.684069,
     "geom:bbox":"73.410667,52.804405,75.775196,53.827809",
     "geom:latitude":53.28444,
     "geom:longitude":74.507219,
@@ -129,9 +129,10 @@
         "hasc:id":"KZ.PA.IR",
         "wd:id":"Q58179"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838100,
-    "wof:geomhash":"d7868dfde2879f92ac58955359c4dfea",
+    "wof:geomhash":"ef2f7b88752c88ee069a4b8864d89f0b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108785679,
-    "wof:lastmodified":1690938400,
+    "wof:lastmodified":1695886677,
     "wof:name":"Irtyshskiy",
     "wof:parent_id":85672911,
     "wof:placetype":"county",

--- a/data/110/878/568/3/1108785683.geojson
+++ b/data/110/878/568/3/1108785683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.153276,
-    "geom:area_square_m":8431068928.402309,
+    "geom:area_square_m":8431068720.292544,
     "geom:bbox":"70.94825,53.180873,72.515494,54.366212",
     "geom:latitude":53.755945,
     "geom:longitude":71.708553,
@@ -117,9 +117,10 @@
         "hasc:id":"KZ.NK.AZ",
         "wd:id":"Q45708"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838101,
-    "wof:geomhash":"2782aec696ebc7214d5fbbd1d67554cb",
+    "wof:geomhash":"4c3f87ff03161e686fc93a828beba229",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108785683,
-    "wof:lastmodified":1690938410,
+    "wof:lastmodified":1695886773,
     "wof:name":"Akzharskiy",
     "wof:parent_id":85672907,
     "wof:placetype":"county",

--- a/data/110/878/568/5/1108785685.geojson
+++ b/data/110/878/568/5/1108785685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.645054,
-    "geom:area_square_m":4638938389.936919,
+    "geom:area_square_m":4638938543.059406,
     "geom:bbox":"68.944851,53.965922,70.155919,54.933445",
     "geom:latitude":54.436836,
     "geom:longitude":69.588467,
@@ -103,7 +103,7 @@
     },
     "wof:country":"KZ",
     "wof:created":1481838102,
-    "wof:geomhash":"1c071adf5a9a220770e88f8b645e6b4c",
+    "wof:geomhash":"81a8a43e4a4dd906a69cb9d2b82749eb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +113,7 @@
         }
     ],
     "wof:id":1108785685,
-    "wof:lastmodified":1690938411,
+    "wof:lastmodified":1695886680,
     "wof:name":"Akkayin",
     "wof:parent_id":85672907,
     "wof:placetype":"county",

--- a/data/110/878/568/7/1108785687.geojson
+++ b/data/110/878/568/7/1108785687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.976113,
-    "geom:area_square_m":7066010837.607789,
+    "geom:area_square_m":7066010583.776847,
     "geom:bbox":"64.666579,53.609899,66.328488,54.716753",
     "geom:latitude":54.166416,
     "geom:longitude":65.485727,
@@ -114,9 +114,10 @@
         "hasc:id":"KZ.QS.UZ",
         "wd:id":"Q964566"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838103,
-    "wof:geomhash":"b815bf6fc82291d30bf177aef84a1f9d",
+    "wof:geomhash":"f585998b3779cc9b415fd6b161fd1591",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108785687,
-    "wof:lastmodified":1690938410,
+    "wof:lastmodified":1695886680,
     "wof:name":"Uzunkol`skiy",
     "wof:parent_id":85672879,
     "wof:placetype":"county",

--- a/data/110/878/568/9/1108785689.geojson
+++ b/data/110/878/568/9/1108785689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.612946,
-    "geom:area_square_m":4485083016.933759,
+    "geom:area_square_m":4485082725.2902,
     "geom:bbox":"65.953484,53.261403,67.182766,54.100829",
     "geom:latitude":53.717582,
     "geom:longitude":66.5542,
@@ -141,9 +141,10 @@
         "hasc:id":"KZ.NK.TI",
         "wd:id":"Q32417"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838104,
-    "wof:geomhash":"0067f73ae151a9c8fda179a9cb68f410",
+    "wof:geomhash":"ae27fc723f587845ed64c32a8d634415",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1108785689,
-    "wof:lastmodified":1690938410,
+    "wof:lastmodified":1695886660,
     "wof:name":"Timiryazevskiy",
     "wof:parent_id":85672907,
     "wof:placetype":"county",

--- a/data/110/878/569/1/1108785691.geojson
+++ b/data/110/878/569/1/1108785691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.162905,
-    "geom:area_square_m":1498490287.763278,
+    "geom:area_square_m":1498490344.978436,
     "geom:bbox":"68.082846,41.775559,68.919,42.09005",
     "geom:latitude":41.934623,
     "geom:longitude":68.509595,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.SK.OT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838105,
-    "wof:geomhash":"bdc7b8649cd7f4e8560fd08d55555b17",
+    "wof:geomhash":"42d15b34a88ca803a28095270290c540",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785691,
-    "wof:lastmodified":1627522313,
+    "wof:lastmodified":1695886777,
     "wof:name":"Otrarskiy",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/569/3/1108785693.geojson
+++ b/data/110/878/569/3/1108785693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.823053,
-    "geom:area_square_m":7619274862.626961,
+    "geom:area_square_m":7619275155.630861,
     "geom:bbox":"68.007275,40.942172,69.460126,41.941759",
     "geom:latitude":41.525057,
     "geom:longitude":68.700078,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.SK.SG",
         "wd:id":"Q2554452"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838107,
-    "wof:geomhash":"50a3147f184f3f3a8170ae8edafa1a0a",
+    "wof:geomhash":"40964426febf29f12e7084d8c13af280",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785693,
-    "wof:lastmodified":1690938400,
+    "wof:lastmodified":1695886677,
     "wof:name":"Saryagashskiy",
     "wof:parent_id":85672927,
     "wof:placetype":"county",

--- a/data/110/878/569/5/1108785695.geojson
+++ b/data/110/878/569/5/1108785695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.583738,
-    "geom:area_square_m":31234721933.504154,
+    "geom:area_square_m":31234721419.434086,
     "geom:bbox":"61.92062,43.505666,64.491987,47.035105",
     "geom:latitude":45.174959,
     "geom:longitude":63.419394,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.QO.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838108,
-    "wof:geomhash":"b3a16baaf7f038464ce50e92012d61ae",
+    "wof:geomhash":"a15a18bea7123dad08b8b33a8a3f7d76",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108785695,
-    "wof:lastmodified":1627522311,
+    "wof:lastmodified":1695886775,
     "wof:name":"Karmakchinskiy",
     "wof:parent_id":85672885,
     "wof:placetype":"county",

--- a/data/110/878/569/7/1108785697.geojson
+++ b/data/110/878/569/7/1108785697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.633445,
-    "geom:area_square_m":4952160172.358404,
+    "geom:area_square_m":4952160267.316096,
     "geom:bbox":"57.284404,50.436709,58.908046,51.180847",
     "geom:latitude":50.783961,
     "geom:longitude":58.103751,
@@ -111,9 +111,10 @@
         "hasc:id":"KZ.AT.KA",
         "wd:id":"Q2550358"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838109,
-    "wof:geomhash":"6ee80ff1152cf16aa5823a6e54080377",
+    "wof:geomhash":"f44b48925913590c06f8ee3bcc414552",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108785697,
-    "wof:lastmodified":1690938399,
+    "wof:lastmodified":1695886676,
     "wof:name":"Kargalinskiy",
     "wof:parent_id":85672877,
     "wof:placetype":"county",

--- a/data/110/878/570/1/1108785701.geojson
+++ b/data/110/878/570/1/1108785701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.329657,
-    "geom:area_square_m":19020177115.294502,
+    "geom:area_square_m":19020176441.169102,
     "geom:bbox":"46.493672,48.068236,49.19986,49.271386",
     "geom:latitude":48.678927,
     "geom:longitude":47.980207,
@@ -102,9 +102,10 @@
         "hasc:id":"KZ.WK.UD",
         "wd:id":"Q2736647"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838110,
-    "wof:geomhash":"7eeea9e4fa32b28f3cb63abd0a5fb018",
+    "wof:geomhash":"cb5126cdf085620f2e966556a4ab3754",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108785701,
-    "wof:lastmodified":1690938442,
+    "wof:lastmodified":1695886696,
     "wof:name":"Urdinskiy",
     "wof:parent_id":85672893,
     "wof:placetype":"county",

--- a/data/110/878/570/3/1108785703.geojson
+++ b/data/110/878/570/3/1108785703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.3874,
-    "geom:area_square_m":19059445836.654484,
+    "geom:area_square_m":19059446242.622757,
     "geom:bbox":"47.536865,49.049647,50.673436,50.673563",
     "geom:latitude":49.786109,
     "geom:longitude":49.076679,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.WK.KZ",
         "wd:id":"Q952951"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838111,
-    "wof:geomhash":"0071692942b1c4995246daca4fbcc48b",
+    "wof:geomhash":"17dd598aa66cf36e5edbcbe885cb93e2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785703,
-    "wof:lastmodified":1690938442,
+    "wof:lastmodified":1695886696,
     "wof:name":"Kaztalovskiy",
     "wof:parent_id":85672893,
     "wof:placetype":"county",

--- a/data/110/878/570/5/1108785705.geojson
+++ b/data/110/878/570/5/1108785705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.550218,
-    "geom:area_square_m":12551119647.095308,
+    "geom:area_square_m":12551120459.694881,
     "geom:bbox":"55.181965,48.407181,57.507489,49.795137",
     "geom:latitude":49.097224,
     "geom:longitude":56.3378,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.AT.TE",
         "wd:id":"Q2550391"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838112,
-    "wof:geomhash":"c8af532b1dd76650173bb261b8fdc0b0",
+    "wof:geomhash":"0b42d50be6bfc7bdaeb31156f63d9537",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785705,
-    "wof:lastmodified":1690938443,
+    "wof:lastmodified":1695886697,
     "wof:name":"Temirskiy",
     "wof:parent_id":85672877,
     "wof:placetype":"county",

--- a/data/110/878/570/7/1108785707.geojson
+++ b/data/110/878/570/7/1108785707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.327314,
-    "geom:area_square_m":11839453269.656687,
+    "geom:area_square_m":11839453628.352665,
     "geom:bbox":"72.82233,43.171422,74.941536,44.650509",
     "geom:latitude":43.83149,
     "geom:longitude":74.056597,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.ZM.SH",
         "wd:id":"Q2422652"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838113,
-    "wof:geomhash":"ce33867021ffd681ff2a8b8c6bdb3cf5",
+    "wof:geomhash":"04d9ab6e9afd8dd369859b2ea7bbfa08",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785707,
-    "wof:lastmodified":1690938442,
+    "wof:lastmodified":1695886696,
     "wof:name":"Shuskiy",
     "wof:parent_id":85672931,
     "wof:placetype":"county",

--- a/data/110/878/570/9/1108785709.geojson
+++ b/data/110/878/570/9/1108785709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.062617,
-    "geom:area_square_m":24549165414.501606,
+    "geom:area_square_m":24549164709.21183,
     "geom:bbox":"49.945462,48.490079,53.425505,50.795924",
     "geom:latitude":49.587753,
     "geom:longitude":51.543034,
@@ -117,9 +117,10 @@
         "hasc:id":"KZ.WK.AK",
         "wd:id":"Q2550287"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838114,
-    "wof:geomhash":"f91a4de708241d2caf51f6c6cfed3941",
+    "wof:geomhash":"6084b0463991c7476a38d5c55ae2097a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108785709,
-    "wof:lastmodified":1690938441,
+    "wof:lastmodified":1695886696,
     "wof:name":"Akzhaikskiy",
     "wof:parent_id":85672893,
     "wof:placetype":"county",

--- a/data/110/878/571/1/1108785711.geojson
+++ b/data/110/878/571/1/1108785711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.935383,
-    "geom:area_square_m":7335393387.109111,
+    "geom:area_square_m":7335393930.212509,
     "geom:bbox":"53.258186,49.997539,54.571897,51.277018",
     "geom:latitude":50.637943,
     "geom:longitude":53.960402,
@@ -117,9 +117,10 @@
         "hasc:id":"KZ.WK.CH",
         "wd:id":"Q2737280"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838115,
-    "wof:geomhash":"789e0c40f5b07230da2a3c857a60ed47",
+    "wof:geomhash":"a23b59a2bb426db4f4dd75a329872a8f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108785711,
-    "wof:lastmodified":1690938436,
+    "wof:lastmodified":1695886693,
     "wof:name":"Chingirlauskiy",
     "wof:parent_id":85672893,
     "wof:placetype":"county",

--- a/data/110/878/571/3/1108785713.geojson
+++ b/data/110/878/571/3/1108785713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.285365,
-    "geom:area_square_m":17827702405.464455,
+    "geom:area_square_m":17827702589.852497,
     "geom:bbox":"76.209652,50.036074,78.791906,51.812778",
     "geom:latitude":50.884647,
     "geom:longitude":77.518899,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.PA.MA",
         "wd:id":"Q2554476"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838117,
-    "wof:geomhash":"df80c073492b3b987bba212ae7cc31ef",
+    "wof:geomhash":"1849d283d7be2b3fd4729fe6f48f2e03",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785713,
-    "wof:lastmodified":1690938436,
+    "wof:lastmodified":1695886693,
     "wof:name":"Mayskiy",
     "wof:parent_id":85672911,
     "wof:placetype":"county",

--- a/data/110/878/571/5/1108785715.geojson
+++ b/data/110/878/571/5/1108785715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.063529,
-    "geom:area_square_m":41500902243.56691,
+    "geom:area_square_m":41500901654.478737,
     "geom:bbox":"60.061136,47.180145,64.269167,49.670953",
     "geom:latitude":48.481346,
     "geom:longitude":62.146074,
@@ -123,9 +123,10 @@
         "hasc:id":"KZ.AT.IR",
         "wd:id":"Q2550383"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838118,
-    "wof:geomhash":"7dd6db02ee8af14ecfe774f754565e26",
+    "wof:geomhash":"baeb490e1d656d6f621db81a973366f6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108785715,
-    "wof:lastmodified":1690938437,
+    "wof:lastmodified":1695886693,
     "wof:name":"Irgizskiy",
     "wof:parent_id":85672877,
     "wof:placetype":"county",

--- a/data/110/878/571/9/1108785719.geojson
+++ b/data/110/878/571/9/1108785719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.403364,
-    "geom:area_square_m":3180247712.141378,
+    "geom:area_square_m":3180247805.681561,
     "geom:bbox":"83.167191,50.116107,84.271928,50.683905",
     "geom:latitude":50.385156,
     "geom:longitude":83.73106,
@@ -107,9 +107,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.EK.LE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838119,
-    "wof:geomhash":"f72ab08acab18b649ae92e0aa0cd8485",
+    "wof:geomhash":"727f4e44f06f86fc2e119ba459948b68",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108785719,
-    "wof:lastmodified":1636495697,
+    "wof:lastmodified":1695886661,
     "wof:name":"Leninogorsk",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/572/1/1108785721.geojson
+++ b/data/110/878/572/1/1108785721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.043417,
-    "geom:area_square_m":7733696702.374777,
+    "geom:area_square_m":7733697016.182427,
     "geom:bbox":"68.541088,52.562322,70.103178,53.652842",
     "geom:latitude":53.171466,
     "geom:longitude":69.266275,
@@ -129,9 +129,10 @@
         "hasc:id":"KZ.AM.ZE",
         "wd:id":"Q2556291"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838120,
-    "wof:geomhash":"d189ba75fd5e3e117c5a685c6f4620fc",
+    "wof:geomhash":"75939086777b892fba0a9e90a6364769",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108785721,
-    "wof:lastmodified":1690938415,
+    "wof:lastmodified":1695886682,
     "wof:name":"Zerendinskiy",
     "wof:parent_id":85672897,
     "wof:placetype":"county",

--- a/data/110/878/572/3/1108785723.geojson
+++ b/data/110/878/572/3/1108785723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.490305,
-    "geom:area_square_m":35647092844.159821,
+    "geom:area_square_m":35647092547.549576,
     "geom:bbox":"59.293483,48.720825,62.950356,51.312203",
     "geom:latitude":50.055664,
     "geom:longitude":61.057675,
@@ -120,9 +120,10 @@
         "hasc:id":"KZ.AT.AY",
         "wd:id":"Q1209360"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838121,
-    "wof:geomhash":"7ea2ed135819ba899fa3b7c572029496",
+    "wof:geomhash":"c65f618c6486c32d57fe0494eb8c6774",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108785723,
-    "wof:lastmodified":1690938415,
+    "wof:lastmodified":1695886682,
     "wof:name":"Aytekebiyskiy",
     "wof:parent_id":85672877,
     "wof:placetype":"county",

--- a/data/110/878/572/5/1108785725.geojson
+++ b/data/110/878/572/5/1108785725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.437204,
-    "geom:area_square_m":27900628902.523129,
+    "geom:area_square_m":27900628753.896988,
     "geom:bbox":"56.560997,47.820119,59.47866,49.861211",
     "geom:latitude":48.967697,
     "geom:longitude":58.076941,
@@ -126,9 +126,10 @@
         "hasc:id":"KZ.AT.MU",
         "wd:id":"Q2550369"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838122,
-    "wof:geomhash":"f6688e5aa4a522f72cde6ebe5a662b78",
+    "wof:geomhash":"8dbfa34acfa84709cfb23fbda53570ed",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108785725,
-    "wof:lastmodified":1690938416,
+    "wof:lastmodified":1695886683,
     "wof:name":"Mugalzharskiy",
     "wof:parent_id":85672877,
     "wof:placetype":"county",

--- a/data/110/878/572/7/1108785727.geojson
+++ b/data/110/878/572/7/1108785727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.40709,
-    "geom:area_square_m":19506433153.429691,
+    "geom:area_square_m":19506432687.822506,
     "geom:bbox":"78.282709,48.271576,80.402533,49.861614",
     "geom:latitude":49.051391,
     "geom:longitude":79.42624,
@@ -138,9 +138,10 @@
         "hasc:id":"KZ.EK.AB",
         "wd:id":"Q1099244"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838123,
-    "wof:geomhash":"e238a97190a28a5a8a7c4266225fb4a9",
+    "wof:geomhash":"9380b3c2392d5c37ec366bf6f2feac21",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1108785727,
-    "wof:lastmodified":1690938415,
+    "wof:lastmodified":1695886682,
     "wof:name":"Abayskiy",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/572/9/1108785729.geojson
+++ b/data/110/878/572/9/1108785729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.944009,
-    "geom:area_square_m":24896101885.886868,
+    "geom:area_square_m":24896101934.642452,
     "geom:bbox":"79.898021,45.53935,83.029644,47.710803",
     "geom:latitude":46.84964,
     "geom:longitude":81.528614,
@@ -132,9 +132,10 @@
         "hasc:id":"KZ.EK.UR",
         "wd:id":"Q2550803"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838124,
-    "wof:geomhash":"36209507fee6fa5b09c8658d39d851a2",
+    "wof:geomhash":"ae66a72650d3223876becc0eb93a48fb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108785729,
-    "wof:lastmodified":1690938414,
+    "wof:lastmodified":1695886682,
     "wof:name":"Urdzharskiy",
     "wof:parent_id":85672915,
     "wof:placetype":"county",

--- a/data/110/878/573/1/1108785731.geojson
+++ b/data/110/878/573/1/1108785731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.067459,
-    "geom:area_square_m":8344119570.324212,
+    "geom:area_square_m":8344119827.667556,
     "geom:bbox":"51.099269,50.008508,52.580962,51.438009",
     "geom:latitude":50.789298,
     "geom:longitude":51.734346,
@@ -114,9 +114,10 @@
         "hasc:id":"KZ.WK.TE",
         "wd:id":"Q2736634"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838125,
-    "wof:geomhash":"b0a125e72868ba8d556a75f8622ff1d0",
+    "wof:geomhash":"01ab8d1a6651229e1e9f550c3aa20c78",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108785731,
-    "wof:lastmodified":1690938420,
+    "wof:lastmodified":1695886684,
     "wof:name":"Terektinskiy",
     "wof:parent_id":85672893,
     "wof:placetype":"county",

--- a/data/110/878/573/3/1108785733.geojson
+++ b/data/110/878/573/3/1108785733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.546442,
-    "geom:area_square_m":19477692975.628193,
+    "geom:area_square_m":19477692867.580769,
     "geom:bbox":"73.658314,50.998539,76.56447,52.552429",
     "geom:latitude":51.785885,
     "geom:longitude":74.917952,
@@ -203,9 +203,10 @@
     "wof:concordances":{
         "hasc:id":"KZ.PA.EK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838126,
-    "wof:geomhash":"ab17ecf199ab185d5db6afe53f6bb86e",
+    "wof:geomhash":"4ec6d5faf4f661f713fb22711e17038e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -215,7 +216,7 @@
         }
     ],
     "wof:id":1108785733,
-    "wof:lastmodified":1636495697,
+    "wof:lastmodified":1695886661,
     "wof:name":"Ekibastuz",
     "wof:parent_id":85672911,
     "wof:placetype":"county",

--- a/data/110/878/573/7/1108785737.geojson
+++ b/data/110/878/573/7/1108785737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.382155,
-    "geom:area_square_m":3469748429.3605,
+    "geom:area_square_m":3469748590.948142,
     "geom:bbox":"70.20676,42.321283,71.23087,43.159682",
     "geom:latitude":42.753942,
     "geom:longitude":70.710325,
@@ -132,9 +132,10 @@
         "hasc:id":"KZ.ZM.ZL",
         "wd:id":"Q2549660"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KZ",
     "wof:created":1481838127,
-    "wof:geomhash":"39b69abfe536b5e756517e79716217ff",
+    "wof:geomhash":"dd36434e44d450659aeeb11f240b9a7e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108785737,
-    "wof:lastmodified":1690938420,
+    "wof:lastmodified":1695886684,
     "wof:name":"Zhualynskiy",
     "wof:parent_id":85672931,
     "wof:placetype":"county",

--- a/data/856/323/07/85632307.geojson
+++ b/data/856/323/07/85632307.geojson
@@ -1376,6 +1376,7 @@
         "hasc:id":"KZ",
         "icao:code":"UN",
         "ioc:id":"KAZ",
+        "iso:code":"KZ",
         "itu:id":"KAZ",
         "m49:code":"398",
         "marc:id":"kz",
@@ -1388,6 +1389,7 @@
         "wk:page":"Kazakhstan",
         "wmo:id":"KZ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KZ",
     "wof:country_alpha3":"KAZ",
     "wof:geom_alt":[
@@ -1413,7 +1415,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1694639597,
+    "wof:lastmodified":1695881258,
     "wof:name":"Kazakhstan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/728/77/85672877.geojson
+++ b/data/856/728/77/85672877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":36.643945,
-    "geom:area_square_m":299518386958.040833,
+    "geom:area_square_m":299518387922.342773,
     "geom:bbox":"53.619211,45.177413,64.269167,51.312203",
     "geom:latitude":48.607204,
     "geom:longitude":58.595421,
@@ -398,16 +398,18 @@
         "gn:id":610688,
         "gp:id":2345980,
         "hasc:id":"KZ.AT",
+        "iso:code":"KZ-AKT",
         "iso:id":"KZ-AKT",
         "qs_pg:id":1222522,
         "wd:id":"Q485437",
         "wk:page":"Aktobe Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4f6a3fbd5ba9b342a70d23312f44b35c",
+    "wof:geomhash":"d2fd050da92e0435ffc2aa59455ed97e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -424,7 +426,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1690938389,
+    "wof:lastmodified":1695884517,
     "wof:name":"Aqt\u00f6be",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/728/79/85672879.geojson
+++ b/data/856/728/79/85672879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":25.475282,
-    "geom:area_square_m":195574526585.914642,
+    "geom:area_square_m":195574528495.342163,
     "geom:bbox":"59.993083,48.172459,68.097924,54.716753",
     "geom:latitude":51.603636,
     "geom:longitude":64.017043,
@@ -382,16 +382,18 @@
         "gn:id":1521671,
         "gp:id":20070176,
         "hasc:id":"KZ.QS",
+        "iso:code":"KZ-KUS",
         "iso:id":"KZ-KUS",
         "qs_pg:id":1085810,
         "wd:id":"Q485605",
         "wk:page":"Kostanay Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"05bb00191deed6e31cd62da2cb726c42",
+    "wof:geomhash":"cb80d633684e18f2f91df0e61785bec1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -408,7 +410,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1690938388,
+    "wof:lastmodified":1695884516,
     "wof:name":"Qostanay",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/728/85/85672885.geojson
+++ b/data/856/728/85/85672885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":25.880053,
-    "geom:area_square_m":225478841729.524567,
+    "geom:area_square_m":225478844625.450958,
     "geom:bbox":"58.929517,42.333889,68.06251,47.841251",
     "geom:latitude":45.192562,
     "geom:longitude":63.647319,
@@ -378,16 +378,18 @@
         "gn:id":1521406,
         "gp:id":2345990,
         "hasc:id":"KZ.QO",
+        "iso:code":"KZ-KZY",
         "iso:id":"KZ-KZY",
         "qs_pg:id":222819,
         "wd:id":"Q485322",
         "wk:page":"Kyzylorda Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fd72202e10f958b8388722c9bcd152f1",
+    "wof:geomhash":"0fdf846d821beae359c691db89363f62",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -404,7 +406,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1690938390,
+    "wof:lastmodified":1695884809,
     "wof:name":"Qyzylorda",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/728/89/85672889.geojson
+++ b/data/856/728/89/85672889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":14.259344,
-    "geom:area_square_m":119013812190.11441,
+    "geom:area_square_m":119013813596.394791,
     "geom:bbox":"47.050191,45.993159,56.474642,49.239258",
     "geom:latitude":47.542944,
     "geom:longitude":52.109026,
@@ -393,16 +393,18 @@
         "gn:id":609862,
         "gp:id":2345986,
         "hasc:id":"KZ.AR",
+        "iso:code":"KZ-ATY",
         "iso:id":"KZ-ATY",
         "qs_pg:id":913682,
         "wd:id":"Q427658",
         "wk:page":"Atyrau Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"100f4db96538768f58ce1f3adfc31cd1",
+    "wof:geomhash":"05f1797ce2ef2e8282a009cb03ce406b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -419,7 +421,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1690938387,
+    "wof:lastmodified":1695884808,
     "wof:name":"Atyrau",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/728/93/85672893.geojson
+++ b/data/856/728/93/85672893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":18.902897,
-    "geom:area_square_m":150812678400.817078,
+    "geom:area_square_m":150812678898.205444,
     "geom:bbox":"46.493672,47.95181,54.57933,51.776105",
     "geom:latitude":49.811989,
     "geom:longitude":50.678007,
@@ -423,16 +423,18 @@
         "gn:id":607847,
         "gp:id":2345998,
         "hasc:id":"KZ.WK",
+        "iso:code":"KZ-ZAP",
         "iso:id":"KZ-ZAP",
         "qs_pg:id":423789,
         "wd:id":"Q486007",
         "wk:page":"West Kazakhstan Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f8452962f5611b0ae5276819bb670b0b",
+    "wof:geomhash":"ec2d09dfea0bbb02b57394295f453323",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -449,7 +451,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1690938386,
+    "wof:lastmodified":1695884808,
     "wof:name":"West Kazakhstan",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/728/97/85672897.geojson
+++ b/data/856/728/97/85672897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":18.85916,
-    "geom:area_square_m":144276977246.044556,
+    "geom:area_square_m":144276976279.935394,
     "geom:bbox":"65.40941,50.039407,74.253596,53.652842",
     "geom:latitude":51.775315,
     "geom:longitude":69.901856,
@@ -399,16 +399,18 @@
         "gn:id":1518003,
         "gp:id":2345996,
         "hasc:id":"KZ.AM",
+        "iso:code":"KZ-AKM",
         "iso:id":"KZ-AKM",
         "qs_pg:id":890084,
         "wd:id":"Q485056",
         "wk:page":"Akmola Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"58a0c3e92bdfe2a497b93d5b37abc78a",
+    "wof:geomhash":"a686064885e8a9214c9159be9254cf42",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -425,7 +427,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1690938387,
+    "wof:lastmodified":1695884517,
     "wof:name":"Aqmola",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/05/85672905.geojson
+++ b/data/856/729/05/85672905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":52.239946,
-    "geom:area_square_m":430236651684.426758,
+    "geom:area_square_m":430236649309.60437,
     "geom:bbox":"62.69539,45.995,77.706204,51.311965",
     "geom:latitude":48.225314,
     "geom:longitude":71.034204,
@@ -406,16 +406,18 @@
         "gn:id":1523401,
         "gp:id":20070178,
         "hasc:id":"KZ.QG",
+        "iso:code":"KZ-KAR",
         "iso:id":"KZ-KAR",
         "qs_pg:id":1062878,
         "wd:id":"Q485429",
         "wk:page":"Karaganda Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6c4e15b832d0ee110bb017554829cd9e",
+    "wof:geomhash":"51b82d20a9be8ae4cd98afad117069c9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -432,7 +434,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1690938390,
+    "wof:lastmodified":1695884518,
     "wof:name":"Qaraghandy",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/07/85672907.geojson
+++ b/data/856/729/07/85672907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":13.518298,
-    "geom:area_square_m":98597738260.877548,
+    "geom:area_square_m":98597738295.249969,
     "geom:bbox":"65.953484,52.20965,74.04072,55.441984",
     "geom:latitude":53.850135,
     "geom:longitude":69.283298,
@@ -415,16 +415,18 @@
         "gn:id":1519367,
         "gp:id":20070174,
         "hasc:id":"KZ.NK",
+        "iso:code":"KZ-SEV",
         "iso:id":"KZ-SEV",
         "qs_pg:id":8656,
         "wd:id":"Q485088",
         "wk:page":"North Kazakhstan Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dce348d59a1a390e24f11cc365451c80",
+    "wof:geomhash":"b2c47a06a697c77b1a40b40dadf68f27",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -441,7 +443,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1690938392,
+    "wof:lastmodified":1695884809,
     "wof:name":"North Kazakhstan",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/11/85672911.geojson
+++ b/data/856/729/11/85672911.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":16.356606,
-    "geom:area_square_m":124307169539.082138,
+    "geom:area_square_m":124307169130.100861,
     "geom:bbox":"73.410667,50.008038,79.339548,54.457595",
     "geom:latitude":52.069063,
     "geom:longitude":76.245247,
@@ -381,16 +381,18 @@
         "gn:id":1520239,
         "gp:id":2345993,
         "hasc:id":"KZ.PA",
+        "iso:code":"KZ-PAV",
         "iso:id":"KZ-PAV",
         "qs_pg:id":890083,
         "wd:id":"Q486144",
         "wk:page":"Pavlodar Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4ce30f9e1a5358350cd544cd64951460",
+    "wof:geomhash":"374a9d468dd8291a9e3d1b286c2740fd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -407,7 +409,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1690938391,
+    "wof:lastmodified":1695884809,
     "wof:name":"Pavlodar",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/15/85672915.geojson
+++ b/data/856/729/15/85672915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":34.251932,
-    "geom:area_square_m":278971291258.055847,
+    "geom:area_square_m":278971291986.188232,
     "geom:bbox":"76.790059,45.53935,87.3154,51.718525",
     "geom:latitude":48.789882,
     "geom:longitude":81.534461,
@@ -418,16 +418,18 @@
         "gn:id":1517381,
         "gp:id":20070175,
         "hasc:id":"KZ.EK",
+        "iso:code":"KZ-VOS",
         "iso:id":"KZ-VOS",
         "qs_pg:id":1085809,
         "wd:id":"Q36156",
         "wk:page":"East Kazakhstan Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"089b912c8b277b3f02af1861f62935fe",
+    "wof:geomhash":"07d5309901feb4747ffd7bc2d9c5b3f7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -444,7 +446,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1690938394,
+    "wof:lastmodified":1695884811,
     "wof:name":"East Kazakhstan",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/21/85672921.geojson
+++ b/data/856/729/21/85672921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":25.257384,
-    "geom:area_square_m":220911471477.064331,
+    "geom:area_square_m":220911471398.966827,
     "geom:bbox":"73.94134,42.210844,82.587726,47.289027",
     "geom:latitude":44.969534,
     "geom:longitude":77.939778,
@@ -388,16 +388,18 @@
         "gn:id":1537162,
         "gp:id":20070180,
         "hasc:id":"KZ.AA",
+        "iso:code":"KZ-ALM",
         "iso:id":"KZ-ALM",
         "qs_pg:id":236956,
         "wd:id":"Q186466",
         "wk:page":"Almaty Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a1f7e29ddb4d7a3e74840f4745fafa50",
+    "wof:geomhash":"374d865a9cb394ae07d65ddff3ceb458",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -414,7 +416,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1690938391,
+    "wof:lastmodified":1695884810,
     "wof:name":"Almaty",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/23/85672923.geojson
+++ b/data/856/729/23/85672923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":18.944394,
-    "geom:area_square_m":168083807758.742432,
+    "geom:area_square_m":168083809310.080475,
     "geom:bbox":"49.993946,41.246392,56.743708,46.510801",
     "geom:latitude":44.13594,
     "geom:longitude":53.945129,
@@ -393,16 +393,18 @@
         "gn:id":608879,
         "gp:id":2345991,
         "hasc:id":"KZ.MG",
+        "iso:code":"KZ-MAN",
         "iso:id":"KZ-MAN",
         "qs_pg:id":222820,
         "wd:id":"Q238931",
         "wk:page":"Mangystau Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2c4a40df405194fa80dce9cef0579771",
+    "wof:geomhash":"f426ce7da04e3fd67d262f3fe9fe2143",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -419,7 +421,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1690938394,
+    "wof:lastmodified":1695884812,
     "wof:name":"Mangghystau",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/27/85672927.geojson
+++ b/data/856/729/27/85672927.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":13.005195,
-    "geom:area_square_m":117159146119.570053,
+    "geom:area_square_m":117159145942.376938,
     "geom:bbox":"65.998692,40.568584,70.943222,46.001822",
     "geom:latitude":43.216874,
     "geom:longitude":68.453802,
@@ -481,16 +481,18 @@
         "gn:id":1524787,
         "gp:id":2345982,
         "hasc:id":"KZ.SK",
+        "iso:code":"KZ-YUZ",
         "iso:id":"KZ-YUZ",
         "qs_pg:id":894911,
         "wd:id":"Q815330",
         "wk:page":"South Kazakhstan Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dbbfd7b57502c4cd9c1fda2add3974a3",
+    "wof:geomhash":"3ec901c1974d636cc75de8aa1a43b387",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -507,7 +509,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1690938390,
+    "wof:lastmodified":1695884809,
     "wof:name":"South Kazakhstan",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/31/85672931.geojson
+++ b/data/856/729/31/85672931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":16.303957,
-    "geom:area_square_m":144216515947.922607,
+    "geom:area_square_m":144216517520.577789,
     "geom:bbox":"69.07439,42.321283,75.823598,46.002765",
     "geom:latitude":44.319904,
     "geom:longitude":72.145956,
@@ -363,16 +363,18 @@
         "gn:id":1524444,
         "gp:id":2345983,
         "hasc:id":"KZ.ZM",
+        "iso:code":"KZ-ZHA",
         "iso:id":"KZ-ZHA",
         "qs_pg:id":318524,
         "wd:id":"Q486657",
         "wk:page":"Jambyl Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d768f5d570481163d9cb5e00579b7a5c",
+    "wof:geomhash":"f47c6a90197a218e82ba530d7498415c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -389,7 +391,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1690938393,
+    "wof:lastmodified":1695884812,
     "wof:name":"Zhambyl",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/37/85672937.geojson
+++ b/data/856/729/37/85672937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077366,
-    "geom:area_square_m":697181337.969643,
+    "geom:area_square_m":697181441.811811,
     "geom:bbox":"76.743077,43.033467,77.166882,43.400639",
     "geom:latitude":43.215843,
     "geom:longitude":76.942392,
@@ -390,11 +390,13 @@
         "gn:id":1537162,
         "gp:id":20070179,
         "hasc:id":"KZ.AC",
+        "iso:code":"KZ-ALA",
         "iso:id":"KZ-ALA",
         "qs_pg:id":332221,
         "wd:id":"Q186466",
         "wk:page":"Almaty Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1108785435
     ],
@@ -402,7 +404,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2abe003c9d637b220b62a2a4cb41197f",
+    "wof:geomhash":"8b8b15a048592627aa4b64f4ed47b749",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -419,7 +421,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1690938393,
+    "wof:lastmodified":1695884339,
     "wof:name":"Almaty City",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/729/41/85672941.geojson
+++ b/data/856/729/41/85672941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090696,
-    "geom:area_square_m":703577514.676455,
+    "geom:area_square_m":703577572.013569,
     "geom:bbox":"71.220936,50.999912,71.728067,51.301212",
     "geom:latitude":51.143772,
     "geom:longitude":71.437183,
@@ -152,10 +152,12 @@
         "gn:id":1538317,
         "gp:id":20070181,
         "hasc:id":"KZ.AS",
+        "iso:code":"KZ-AST",
         "iso:id":"KZ-AST",
         "qs_pg:id":349676,
         "unlc:id":"KZ-AST"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421191125
     ],
@@ -163,7 +165,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"98ef2f6f0e6ad4977f0812601bbfa77a",
+    "wof:geomhash":"b13b8d0851299c00f94652b72061b851",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -180,7 +182,7 @@
         "rus",
         "kaz"
     ],
-    "wof:lastmodified":1627522312,
+    "wof:lastmodified":1695884755,
     "wof:name":"Astana",
     "wof:parent_id":85632307,
     "wof:placetype":"region",

--- a/data/856/812/65/85681265.geojson
+++ b/data/856/812/65/85681265.geojson
@@ -152,8 +152,10 @@
         "gn:id":1538316,
         "gp:id":-2345990,
         "hasc:id":"KZ.BY",
+        "iso:code":"KZ-BAY",
         "iso:id":"KZ-BAY"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KZ",
     "wof:geomhash":"6bfbbdaaad57122ded05b7f849d057b5",
     "wof:hierarchy":[
@@ -165,7 +167,7 @@
         }
     ],
     "wof:id":85681265,
-    "wof:lastmodified":1694493254,
+    "wof:lastmodified":1695884755,
     "wof:name":"Baykonur lease in Qyzylorda",
     "wof:parent_id":85632685,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.